### PR TITLE
Responsive tweaks

### DIFF
--- a/jazzmin/static/jazzmin/css/django.css
+++ b/jazzmin/static/jazzmin/css/django.css
@@ -629,3 +629,15 @@ body.no-sidebar .content-wrapper, body.no-sidebar .main-footer, body.no-sidebar 
     opacity: 1;
     border: 1px solid white;
 }
+
+.timeline-item {
+    word-break: break-word;
+}
+
+.brand-link {
+    padding-top: 3px;
+}
+
+.breadcrumb {
+    margin-top: 5px;
+}

--- a/jazzmin/templates/admin/auth/user/change_password.html
+++ b/jazzmin/templates/admin/auth/user/change_password.html
@@ -52,18 +52,18 @@
 
                             <fieldset class="module aligned">
                                 <div class="row form-group">
-                                    <div class="col-2">
-                                        <label class="control-label float-right">
+                                    <div class="col-12 col-md-2">
+                                        <label class="control-label float-md-right">
                                             {{ form.password1.field.label }}
                                         </label>
                                     </div>
-                                    <div class="col-6">
+                                    <div class="col-12 col-md-6">
                                         {{ form.password1 }}
                                         {% if form.password1.help_text %}
                                             <div class="help-block">{{ form.password1.help_text|safe }}</div>
                                         {% endif %}
                                     </div>
-                                    <div class="col-4">
+                                    <div class="col-12 col-md-4">
                                         <div class="help-block text-red">
                                             {{ form.password1.errors }}
                                         </div>
@@ -71,18 +71,18 @@
                                 </div>
 
                                 <div class="row form-group">
-                                    <div class="col-2">
-                                        <label class="control-label float-right">
+                                    <div class="col-12 col-md-2">
+                                        <label class="control-label float-md-right">
                                             {{ form.password2.field.label }}
                                         </label>
                                     </div>
-                                    <div class="col-6">
+                                    <div class="col-12 col-md-6">
                                         {{ form.password2 }}
                                         {% if form.password2.help_text %}
                                             <div class="help-block">{{ form.password2.help_text|safe }}</div>
                                         {% endif %}
                                     </div>
-                                    <div class="col-4">
+                                    <div class="col-12 col-md-4">
                                         <div class="help-block text-red">
                                             {{ form.password2.errors }}
                                         </div>

--- a/jazzmin/templates/admin/auth/user/change_password.html
+++ b/jazzmin/templates/admin/auth/user/change_password.html
@@ -23,7 +23,7 @@
 
 {% block content %}
 
-    <div class=col-12>
+    <div class="col-12">
         {% if form.errors %}
             <div class="callout callout-danger">
                 {% if errors|length == 1 %}
@@ -52,18 +52,18 @@
 
                             <fieldset class="module aligned">
                                 <div class="row form-group">
-                                    <div class=col-2>
+                                    <div class="col-2">
                                         <label class="control-label float-right">
                                             {{ form.password1.field.label }}
                                         </label>
                                     </div>
-                                    <div class=col-6>
+                                    <div class="col-6">
                                         {{ form.password1 }}
                                         {% if form.password1.help_text %}
                                             <div class="help-block">{{ form.password1.help_text|safe }}</div>
                                         {% endif %}
                                     </div>
-                                    <div class=col-4>
+                                    <div class="col-4">
                                         <div class="help-block text-red">
                                             {{ form.password1.errors }}
                                         </div>
@@ -71,18 +71,18 @@
                                 </div>
 
                                 <div class="row form-group">
-                                    <div class=col-2>
+                                    <div class="col-2">
                                         <label class="control-label float-right">
                                             {{ form.password2.field.label }}
                                         </label>
                                     </div>
-                                    <div class=col-6>
+                                    <div class="col-6">
                                         {{ form.password2 }}
                                         {% if form.password2.help_text %}
                                             <div class="help-block">{{ form.password2.help_text|safe }}</div>
                                         {% endif %}
                                     </div>
-                                    <div class=col-4>
+                                    <div class="col-4">
                                         <div class="help-block text-red">
                                             {{ form.password2.errors }}
                                         </div>

--- a/jazzmin/templates/admin/base.html
+++ b/jazzmin/templates/admin/base.html
@@ -85,9 +85,11 @@
             <ul class="navbar-nav ml-auto">
 
                 <li class="nav-item dropdown">
-                    <a class="nav-link btn" data-toggle="dropdown" href="#">
-                        {{ request.user }} <i class="far fa-user pr-2" aria-hidden="true"></i>
+                    {% if perms|can_view_self %}
+                    <a class="nav-link btn" data-toggle="dropdown" href="#" title="{{ request.user }}">
+                        <i class="far fa-user pr-2" aria-hidden="true"></i>
                     </a>
+                    {% endif %}
                     <div class="dropdown-menu dropdown-menu-lg dropdown-menu-right">
                         <span class="dropdown-header">{% trans 'Account' %}</span>
                         <div class="dropdown-divider"></div>

--- a/jazzmin/templates/admin/base_site.html
+++ b/jazzmin/templates/admin/base_site.html
@@ -9,10 +9,10 @@
     <div class="content-header">
         <div class="container-fluid">
             <div class="row mb-2">
-                <div class="col-3">
+                <div class="col-auto col-sm-3">
                     <h1 class="m-0 text-dark">{% block content_title %}{% endblock %}</h1>
                 </div>
-                <div class="col-9">
+                <div class="col-auto col-sm-9">
                     {% block breadcrumbs %}{% endblock %}
                 </div>
             </div>

--- a/jazzmin/templates/admin/change_form.html
+++ b/jazzmin/templates/admin/change_form.html
@@ -37,7 +37,7 @@
 
 {% block content %}
 
-    <div id="content-main" class=col-12>
+    <div id="content-main" class="col-12">
         <form {% if has_file_field %}enctype="multipart/form-data" {% endif %}action="{{ form_url }}" method="post" id="{{ opts.model_name }}_form" novalidate>
             {% csrf_token %}
             {% block form_top %}{% endblock %}
@@ -63,7 +63,7 @@
                 {% if to_field %}<input type="hidden" name="{{ to_field_var }}" value="{{ to_field }}">{% endif %}
 
                 {% block field_sets %}
-                    <div class="col-md-9 col-sm-12">
+                    <div class="col-12 col-lg-9">
                         <div class="card card-primary card-outline">
                             <div class="card-header">
                                 <div class="card-title">
@@ -74,12 +74,7 @@
                                 <ul class="nav nav-tabs" role="tablist">
                                     {% for fieldset in adminform %}
                                         <li class="nav-item">
-                                            <a id="{{ fieldset.name|default:"General"|slugify }}-tab"
-                                               class="nav-link{% if forloop.first %} active{% endif %}"
-                                               data-toggle="pill" role="tab"
-                                               aria-controls={{ fieldset.name|default:"General"|slugify }}" aria-selected="
-                                               {% if forloop.first %}true{% else %}false{% endif %}"
-                                            href="#{{ fieldset.name|default:"General"|slugify }}">{{ fieldset.name|default:"General"|title }}</a>
+                                            <a id="{{ fieldset.name|default:"General"|slugify }}-tab" class="nav-link{% if forloop.first %} active{% endif %}" data-toggle="pill" role="tab" aria-controls="{{ fieldset.name|default:"General"|slugify }}" aria-selected="{% if forloop.first %}true{% else %}false{% endif %}" href="#{{ fieldset.name|default:"General"|slugify }}">{{ fieldset.name|default:"General"|title }}</a>
                                         </li>
                                     {% endfor %}
                                     {% for inline_admin_formset in inline_admin_formsets %}
@@ -124,7 +119,7 @@
                 {% block after_related_objects %}{% endblock %}
 
                 {% block submit_buttons_bottom %}
-                    <div class="col-md-3 col-sm-12">
+                    <div class="col-12 col-lg-3">
                         {% submit_row %}
                         {% block object-tools %}
                             {% if change %}

--- a/jazzmin/templates/admin/change_list.html
+++ b/jazzmin/templates/admin/change_list.html
@@ -73,12 +73,12 @@
 
                                     {% block result_list %}
                                         <div class="row">
-                                            <div class=col-8>
+                                            <div class="col-12 col-sm-8">
                                                 {% if action_form and actions_on_top and cl.show_admin_actions %}
                                                     {% admin_actions %}
                                                 {% endif %}
                                             </div>
-                                            <div class=col-4>
+                                            <div class="col-12 col-sm-4">
                                                 {% block object-tools %}
                                                     {% block object-tools-items %}
                                                         {% change_list_object_tools %}
@@ -90,7 +90,7 @@
                                         {% result_list cl %}
                                         {% if action_form and actions_on_bottom and cl.show_admin_actions %}
                                             <div class="row">
-                                                <div class=col-12>
+                                                <div class="col-12">
                                                     {% admin_actions %}
                                                 </div>
                                             </div>

--- a/jazzmin/templates/admin/date_hierarchy.html
+++ b/jazzmin/templates/admin/date_hierarchy.html
@@ -1,5 +1,5 @@
 {% if show %}
-    <div class="btn-group date-hierarchy text-sm">
+    <div class="btn-group date-hierarchy text-sm mt-sm-2">
         {% block date-hierarchy-toplinks %}
             {% block date-hierarchy-back %}
                 {% if back %}

--- a/jazzmin/templates/admin/date_hierarchy.html
+++ b/jazzmin/templates/admin/date_hierarchy.html
@@ -1,5 +1,5 @@
 {% if show %}
-    <div class="btn-group date-hierarchy text-sm mt-sm-2">
+    <div class="btn-group date-hierarchy text-sm mt-2">
         {% block date-hierarchy-toplinks %}
             {% block date-hierarchy-back %}
                 {% if back %}

--- a/jazzmin/templates/admin/delete_confirmation.html
+++ b/jazzmin/templates/admin/delete_confirmation.html
@@ -23,7 +23,7 @@
 
 {% block content %}
 
-<div class=col-12>
+<div class="col-12">
     <div class="card card-danger card-outline">
         <div class="card-header with-border">
             <h4 class="card-title">

--- a/jazzmin/templates/admin/delete_selected_confirmation.html
+++ b/jazzmin/templates/admin/delete_selected_confirmation.html
@@ -23,7 +23,7 @@
 {% block content %}
 
 <div class="row">
-    <div class=col-12>
+    <div class="col-12">
         <div class="card card-danger card-outline">
             <div class="card-header with-border">
                 <h4 class="card-title">

--- a/jazzmin/templates/admin/index.html
+++ b/jazzmin/templates/admin/index.html
@@ -19,7 +19,7 @@
         {% widthratio dashboard_list|length 2 1 as middle %}
     {% endif %}
 
-    <div class="col-md-9 col-sm-12">
+    <div class="col-lg-9 col-12">
         <div class="row">
             <div class="col-md-6 col-sm-12">
                 {% for app in dashboard_list %}
@@ -66,7 +66,7 @@
         </div>
 
     </div>
-    <div class="col-md-3 col-sm-12">
+    <div class="col-lg-3 col-12">
         <div id="content-related">
             <div class="module" id="recent-actions-module">
                 <h3>{% trans 'Recent actions' %}</h3>

--- a/jazzmin/templates/admin/login.html
+++ b/jazzmin/templates/admin/login.html
@@ -78,7 +78,7 @@
                     </div>
                 </div>
                 <div class="row">
-                    <div class=col-12>
+                    <div class="col-12">
                         <button type="submit" class="btn btn-primary btn-block">{% trans "Log in" %}</button>
                     </div>
                 </div>

--- a/jazzmin/templates/admin/object_history.html
+++ b/jazzmin/templates/admin/object_history.html
@@ -14,7 +14,7 @@
 {% block content %}
 
 <div class="row col-md-12">
-    <div class=col-12>
+    <div class="col-12">
         <div class="card card-primary card-outline">
             <div class="card-header with-border">
                 <h4 class="card-title">

--- a/jazzmin/templates/admin/search_form.html
+++ b/jazzmin/templates/admin/search_form.html
@@ -1,6 +1,6 @@
 {% load i18n static admin_list jazzmin %}
 
-<form id="changelist-search" class="form-inline" method="GET">
+<form id="changelist-search" class="form-inline mt-sm-2" method="GET">
     {% block filters %}
         {% if cl.has_filters %}
             {% for spec in cl.filter_specs %}{% jazzmin_list_filter cl spec %}{% endfor %}

--- a/jazzmin/templates/admin/search_form.html
+++ b/jazzmin/templates/admin/search_form.html
@@ -1,6 +1,6 @@
 {% load i18n static admin_list jazzmin %}
 
-<form id="changelist-search" class="form-inline mt-sm-2" method="GET">
+<form id="changelist-search" class="form-inline mt-2" method="GET">
     {% block filters %}
         {% if cl.has_filters %}
             {% for spec in cl.filter_specs %}{% jazzmin_list_filter cl spec %}{% endfor %}

--- a/jazzmin/templates/admin/submit_line.html
+++ b/jazzmin/templates/admin/submit_line.html
@@ -9,47 +9,35 @@
         </h3>
     </div>
     <div class="card-body">
-        <div class="row">
-            <div class="form-group col-md-12">
-                {% if show_save %}
-                    <input type="submit" value="{% trans 'Save' %}" class="btn btn-success form-control" name="_save">
-                {% endif %}
-            </div>
+        <div class="form-group">
+            {% if show_save %}
+                <input type="submit" value="{% trans 'Save' %}" class="btn btn-success form-control" name="_save">
+            {% endif %}
         </div>
         {% if show_delete_link and original %}
-            <div class="row">
-                <div class="form-group col-md-12">
+            <div class="form-group">
                     {% url opts|admin_urlname:'delete' original.pk|admin_urlquote as delete_url %}
                     <a href="{% add_preserved_filters delete_url %}" class="btn btn-danger form-control">{% trans "Delete" %}</a>
                 </div>
-            </div>
         {% endif %}
         {% if show_save_as_new %}
-            <div class="row">
-                <div class="form-group col-md-12">
+            <div class="form-group">
                     <input type="submit" class="btn btn-outline-info form-control" value="{% trans 'Save as new' %}" name="_saveasnew">
                 </div>
-            </div>
         {% endif %}
         {% if show_save_and_add_another %}
-            <div class="row">
-                <div class="form-group col-md-12">
+            <div class="form-group">
                     <input type="submit" class="btn btn-outline-info form-control" value="{% trans 'Save and add another' %}" name="_addanother">
                 </div>
-            </div>
         {% endif %}
         {% if show_save_and_continue %}
-            <div class="row">
-                <div class="form-group col-md-12">
+            <div class="form-group">
                     <input type="submit" class="btn btn-outline-info form-control" value="{% if can_change %}{% trans 'Save and continue editing' %}{% else %}{% trans 'Save and view' %}{% endif %}" name="_continue"></div>
-            </div>
         {% endif %}
         {% if show_close %}
-            <div class="row">
-                <div class="form-group col-md-12">
+            <div class="form-group">
                     <a href="{% url opts|admin_urlname:'changelist' %}" class="btn btn-outline-danger form-control">{% trans 'Close' %}</a>
                 </div>
-            </div>
         {% endif %}
     </div>
 </div>

--- a/jazzmin/templates/registration/password_change_done.html
+++ b/jazzmin/templates/registration/password_change_done.html
@@ -16,7 +16,7 @@
 {% block title %}{{ title }}{% endblock %}
 {% block content_title %} {{ title }} {% endblock %}
 {% block content %}
-    <div id="content-main" class=col-12>
+    <div id="content-main" class="col-12">
         <div class="callout callout-success">
             <p>{% trans 'Your password was changed.' %}</p>
         </div>

--- a/jazzmin/templates/registration/password_change_form.html
+++ b/jazzmin/templates/registration/password_change_form.html
@@ -44,18 +44,18 @@
 
                             <fieldset class="module aligned">
                                 <div class="row form-group">
-                                    <div class=col-2>
-                                        <label class="control-label float-right">
+                                    <div class="col-12 col-md-2">
+                                        <label class="control-label float-md-right">
                                             {{ form.old_password.field.label }}
                                         </label>
                                     </div>
-                                    <div class=col-6>
+                                    <div class="col-12 col-md-6">
                                         {{ form.old_password }}
                                         {% if form.old_password.help_text %}
                                         <div class="help-block">{{ form.old_password.help_text|safe }}</div>
                                         {% endif %}
                                     </div>
-                                    <div class=col-4>
+                                    <div class="col-12 col-md-4">
                                         <div class="help-block text-red">
                                             {{ form.old_password.errors }}
                                         </div>
@@ -63,18 +63,18 @@
                                 </div>
 
                                 <div class="row form-group">
-                                    <div class=col-2>
-                                        <label class="control-label float-right">
+                                    <div class="col-12 col-md-2">
+                                        <label class="control-label float-md-right">
                                             {{ form.new_password1.field.label }}
                                         </label>
                                     </div>
-                                    <div class=col-6>
+                                    <div class="col-12 col-md-6">
                                         {{ form.new_password1 }}
                                         {% if form.new_password1.help_text %}
                                         <div class="help-block">{{ form.new_password1.help_text|safe }}</div>
                                         {% endif %}
                                     </div>
-                                    <div class=col-4>
+                                    <div class="col-12 col-md-4">
                                         <div class="help-block text-red">
                                             {{ form.new_password1.errors }}
                                         </div>
@@ -82,18 +82,18 @@
                                 </div>
 
                                 <div class="row form-group">
-                                    <div class=col-2>
-                                        <label class="control-label float-right">
+                                    <div class="col-12 col-md-2">
+                                        <label class="control-label float-md-right">
                                             {{ form.new_password2.field.label }}
                                         </label>
                                     </div>
-                                    <div class=col-6>
+                                    <div class="col-12 col-md-6">
                                         {{ form.new_password2 }}
                                         {% if form.new_password1.help_text %}
                                         <div class="help-block">{{ form.new_password2.help_text|safe }}</div>
                                         {% endif %}
                                     </div>
-                                    <div class=col-4>
+                                    <div class="col-12 col-md-4">
                                         <div class="help-block text-red">
                                             {{ form.new_password2.errors }}
                                         </div>


### PR DESCRIPTION
Go through all breakpoints again, 

- Use `col-12` or `col-auto` as starting size
- Use `col-md-x` or `col-lg-x` as content scales up and looks decent
- Fix class names without qoutes
- Removes username from user menu, just uses icon now


Aims to fix https://github.com/farridav/django-jazzmin/issues/49

