### PR TITLE
Remove tabs on single fieldsets

### DIFF
--- a/jazzmin/templates/admin/change_form.html
+++ b/jazzmin/templates/admin/change_form.html
@@ -72,42 +72,52 @@
                                 </div>
                             </div>
                             <div class="card-body">
-                                <ul class="nav nav-tabs" role="tablist">
+                                {% if inline_admin_formsets|length_is:'0' %}
                                     {% for fieldset in adminform %}
-                                        <li class="nav-item">
-                                            <a id="{{ fieldset.name|default:"General"|slugify }}-tab" class="nav-link{% if forloop.first %} active{% endif %}" data-toggle="pill" role="tab" aria-controls="{{ fieldset.name|default:"General"|slugify }}" aria-selected="{% if forloop.first %}true{% else %}false{% endif %}" href="#{{ fieldset.name|default:"General"|slugify }}">{{ fieldset.name|default:"General"|title }}</a>
-                                        </li>
+                                        {% include "admin/includes/fieldset.html" with single=True %}
                                     {% endfor %}
                                     {% for inline_admin_formset in inline_admin_formsets %}
-                                        <li class="nav-item">
-                                            <a id="{{ inline_admin_formset.opts.verbose_name_plural|slugify }}-tab"
-                                               class="nav-link" data-toggle="pill" role="tab"
-                                               aria-controls="{{ inline_admin_formset.opts.verbose_name_plural|slugify }}"
-                                               aria-selected="false"
-                                               href="#{{ inline_admin_formset.opts.verbose_name_plural|slugify }}">
-                                                {{ inline_admin_formset.opts.verbose_name_plural|title }}
-                                            </a>
-                                        </li>
+                                        {% include inline_admin_formset.opts.template %}
                                     {% endfor %}
-                                </ul>
+                                {% else %}
+                                    <ul class="nav nav-tabs" role="tablist">
+                                        {% for fieldset in adminform %}
+                                            <li class="nav-item">
+                                                <a id="{{ fieldset.name|default:"General"|slugify }}-tab" class="nav-link{% if forloop.first %} active{% endif %}" data-toggle="pill" role="tab" aria-controls="{{ fieldset.name|default:"General"|slugify }}" aria-selected="{% if forloop.first %}true{% else %}false{% endif %}" href="#{{ fieldset.name|default:"General"|slugify }}">{{ fieldset.name|default:"General"|title }}</a>
+                                            </li>
+                                        {% endfor %}
+                                        {% for inline_admin_formset in inline_admin_formsets %}
+                                            <li class="nav-item">
+                                                <a id="{{ inline_admin_formset.opts.verbose_name_plural|slugify }}-tab"
+                                                   class="nav-link" data-toggle="pill" role="tab"
+                                                   aria-controls="{{ inline_admin_formset.opts.verbose_name_plural|slugify }}"
+                                                   aria-selected="false"
+                                                   href="#{{ inline_admin_formset.opts.verbose_name_plural|slugify }}">
+                                                    {{ inline_admin_formset.opts.verbose_name_plural|title }}
+                                                </a>
+                                            </li>
+                                        {% endfor %}
+                                    </ul>
 
-                                <div class="tab-content" id="custom-tabs-one-tabContent">
-                                    {% for fieldset in adminform %}
-                                        <div id="{{ fieldset.name|default:"General"|slugify }}"
-                                             class="tab-pane fade{% if forloop.first %} active show{% endif %}"
-                                             role="tabpanel"
-                                             aria-labelledby="{{ fieldset.name|default:"General"|slugify }}-tab">
-                                            {% include "admin/includes/fieldset.html" %}
-                                        </div>
-                                    {% endfor %}
-                                    {% for inline_admin_formset in inline_admin_formsets %}
-                                        <div id="{{ inline_admin_formset.opts.verbose_name_plural|slugify }}"
-                                             class="tab-pane fade" role="tabpanel"
-                                             aria-labelledby="{{ inline_admin_formset.opts.verbose_name_plural|slugify }}-tab">
-                                            {% include inline_admin_formset.opts.template %}
-                                        </div>
-                                    {% endfor %}
-                                </div>
+                                    <div class="tab-content" id="custom-tabs-one-tabContent">
+                                        {% for fieldset in adminform %}
+                                            <div id="{{ fieldset.name|default:"General"|slugify }}"
+                                                 class="tab-pane fade{% if forloop.first %} active show{% endif %}"
+                                                 role="tabpanel"
+                                                 aria-labelledby="{{ fieldset.name|default:"General"|slugify }}-tab">
+                                                {% include "admin/includes/fieldset.html" %}
+                                            </div>
+                                        {% endfor %}
+                                        {% for inline_admin_formset in inline_admin_formsets %}
+                                            <div id="{{ inline_admin_formset.opts.verbose_name_plural|slugify }}"
+                                                 class="tab-pane fade" role="tabpanel"
+                                                 aria-labelledby="{{ inline_admin_formset.opts.verbose_name_plural|slugify }}-tab">
+                                                {% include inline_admin_formset.opts.template %}
+                                            </div>
+                                        {% endfor %}
+                                    </div>
+                                {% endif %}
+
                             </div>
                         </div>
                     </div>

--- a/jazzmin/templates/admin/includes/fieldset.html
+++ b/jazzmin/templates/admin/includes/fieldset.html
@@ -1,6 +1,8 @@
 {% load jazzmin %}
+{% if not single %}
 <div class="card {{ fieldset.classes|cut:"collapse" }}">
     <div class="p-5{% if fieldset.name %} card-body{% endif %}">
+{% endif %}
         {% for line in fieldset %}
         <div class="form-group{% if line.fields|length_is:'1' and line.errors %} errors{% endif %}{% if not line.has_visible_field %} hidden{% endif %}{% for field in line %}{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% endfor %}">
             <div class="row">
@@ -31,5 +33,7 @@
             </div>
         </div>
         {% endfor %}
+{% if not single %}
     </div>
 </div>
+{% endif %}

--- a/tox.ini
+++ b/tox.ini
@@ -28,4 +28,4 @@ deps =
 passenv = COVERALLS_REPO_TOKEN
 commands =
     coverage run -m py.test
-    coveralls
+    coveralls 2> /dev/null

--- a/tox.ini
+++ b/tox.ini
@@ -28,4 +28,4 @@ deps =
 passenv = COVERALLS_REPO_TOKEN
 commands =
     coverage run -m py.test
-    coveralls 2> /dev/null
+    coveralls


### PR DESCRIPTION
- When we have no fieldsets in our admin, avoid the use of tabs.

Extra:
- Stop coveralls complaining when somebody else makes a PR (it cant access this repos secrets)

Fixes: https://github.com/farridav/django-jazzmin/issues/65

![single_fieldset](https://user-images.githubusercontent.com/2966253/85123582-674cb780-b220-11ea-83b0-2f3b691e7d8d.png)
