### PR TITLE
Add missing title to login template

### DIFF
--- a/jazzmin/templates/admin/login.html
+++ b/jazzmin/templates/admin/login.html
@@ -9,7 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
 
-    <title>{% block title %}{% endblock %}</title>
+    <title>{% block title %}{{ title }} | {{ jazzmin_settings.site_title }}{% endblock %}</title>
 
     <!-- Font Awesome Icons -->
     <link rel="stylesheet" href="{% static "adminlte/plugins/fontawesome-free/css/all.min.css" %}">


### PR DESCRIPTION
- Fixes #75

Had to do it this way as extending `base.html` was a bit of a fiddle. Login page could be a candidate for jazzing 😄 