### PR TITLE
Minor tweak to top menu naming

### DIFF
--- a/jazzmin/utils.py
+++ b/jazzmin/utils.py
@@ -3,8 +3,7 @@ from urllib.parse import urlencode
 
 from django.apps import apps
 from django.db.models.base import ModelBase
-
-from jazzmin.compat import reverse, NoReverseMatch
+from jazzmin.compat import NoReverseMatch, reverse
 
 logger = logging.getLogger(__name__)
 
@@ -34,24 +33,17 @@ def get_admin_url(instance, **kwargs):
 
         if type(instance) == str:
             app_label, model_name = instance.lower().split(".")
-            url = reverse(
-                "admin:{app_label}_{model_name}_changelist".format(app_label=app_label, model_name=model_name)
-            )
+            url = reverse("admin:{app_label}_{model_name}_changelist".format(app_label=app_label, model_name=model_name))
 
         # Model class
         elif instance.__class__ == ModelBase:
             app_label, model_name = instance._meta.app_label, instance._meta.model_name
-            url = reverse(
-                "admin:{app_label}_{model_name}_changelist".format(app_label=app_label, model_name=model_name)
-            )
+            url = reverse("admin:{app_label}_{model_name}_changelist".format(app_label=app_label, model_name=model_name))
 
         # Model instance
         elif instance.__class__.__class__ == ModelBase and isinstance(instance, instance.__class__):
             app_label, model_name = instance._meta.app_label, instance._meta.model_name
-            url = reverse(
-                "admin:{app_label}_{model_name}_change".format(app_label=app_label, model_name=model_name),
-                args=(instance.pk,),
-            )
+            url = reverse("admin:{app_label}_{model_name}_change".format(app_label=app_label, model_name=model_name), args=(instance.pk,),)
 
     except (NoReverseMatch, ValueError):
         logger.error("Couldnt reverse url from {instance}".format(instance=instance))
@@ -181,7 +173,7 @@ def make_menu(user, links, options, allow_appmenus=True):
         # App links
         elif "app" in link and allow_appmenus:
             children = [
-                {"name": child["name"], "url": child["url"], "children": None}
+                {"name": child.get("verbose_name", child["name"]), "url": child["url"], "children": None}
                 for child in get_app_admin_urls(link["app"])
                 if child["model"] in model_permissions
             ]

--- a/jazzmin/utils.py
+++ b/jazzmin/utils.py
@@ -33,17 +33,24 @@ def get_admin_url(instance, **kwargs):
 
         if type(instance) == str:
             app_label, model_name = instance.lower().split(".")
-            url = reverse("admin:{app_label}_{model_name}_changelist".format(app_label=app_label, model_name=model_name))
+            url = reverse(
+                "admin:{app_label}_{model_name}_changelist".format(app_label=app_label, model_name=model_name)
+            )
 
         # Model class
         elif instance.__class__ == ModelBase:
             app_label, model_name = instance._meta.app_label, instance._meta.model_name
-            url = reverse("admin:{app_label}_{model_name}_changelist".format(app_label=app_label, model_name=model_name))
+            url = reverse(
+                "admin:{app_label}_{model_name}_changelist".format(app_label=app_label, model_name=model_name)
+            )
 
         # Model instance
         elif instance.__class__.__class__ == ModelBase and isinstance(instance, instance.__class__):
             app_label, model_name = instance._meta.app_label, instance._meta.model_name
-            url = reverse("admin:{app_label}_{model_name}_change".format(app_label=app_label, model_name=model_name), args=(instance.pk,),)
+            url = reverse(
+                "admin:{app_label}_{model_name}_change".format(app_label=app_label, model_name=model_name),
+                args=(instance.pk,),
+            )
 
     except (NoReverseMatch, ValueError):
         logger.error("Couldnt reverse url from {instance}".format(instance=instance))


### PR DESCRIPTION
The name of the top menu currently uses the AppConfig `name` property. This edit changes how that property is accessed so that it uses the `verbose_name` field if it's supplied and defaults to `name` as the default.