### PR TITLE
Use 'verbose_name' in top menu link titles

### DIFF
--- a/jazzmin/utils.py
+++ b/jazzmin/utils.py
@@ -189,7 +189,9 @@ def make_menu(user, links, options, allow_appmenus=True):
 
             menu.append(
                 {
-                    "name": link["app"].title(),
+                    "name": apps.app_configs[link["app"]].verbose_name.title() 
+                            if hasattr(apps.app_configs[link["app"]], 'verbose_name') 
+                            else link["app"].title(),
                     "url": "#",
                     "children": children,
                     "icon": options["icons"].get(link["app"], options["default_icon_children"]),


### PR DESCRIPTION
Fix utils.py to use 'verbose_name' property, if specified in AppConfig, in the rendered links inside the top menu.