### PR TITLE
Fix usermenu

### DIFF
--- a/jazzmin/templates/admin/base.html
+++ b/jazzmin/templates/admin/base.html
@@ -100,11 +100,9 @@
                 {% endif %}
 
                 <li class="nav-item dropdown">
-                    {% if perms|can_view_self %}
                     <a class="nav-link btn" data-toggle="dropdown" href="#" title="{{ request.user }}">
                         <i class="far fa-user pr-2" aria-hidden="true"></i>
                     </a>
-                    {% endif %}
                     <div class="dropdown-menu dropdown-menu-lg dropdown-menu-left" id="jazzy-usermenu">
                         <span class="dropdown-header">{% trans 'Account' %}</span>
                         <div class="dropdown-divider"></div>


### PR DESCRIPTION
Users without view_user permission cannot see the usermenu, which makes these users unable to log out or change their passwords. This bug first appeared in a0cca8b