### PR TITLE
Allow for upper case app names

### DIFF
--- a/jazzmin/utils.py
+++ b/jazzmin/utils.py
@@ -127,7 +127,8 @@ def get_view_permissions(user):
     """
     Get model names based on a users view permissions
     """
-    return {x.replace("view_", "") for x in user.get_all_permissions() if "view" in x}
+    lower_perms = map(lambda x: x.lower(), user.get_all_permissions())
+    return {x.replace("view_", "") for x in lower_perms if "view" in x}
 
 
 def make_menu(user, links, options, allow_appmenus=True):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import pytest
+from django.db.models.functions import Upper
 from django.urls import reverse
 
 from jazzmin.utils import (
@@ -70,30 +71,12 @@ def test_get_app_admin_urls():
     We can get all the admin urls for an app
     """
     assert get_app_admin_urls("polls") == [
-        {
-            "model": "polls.poll", "name": "Polls",
-            "url": reverse("admin:polls_poll_changelist")
-        },
-        {
-            "model": "polls.choice", "name": "Choices",
-            "url": reverse("admin:polls_choice_changelist")
-        },
-        {
-            "model": "polls.vote", "name": "Votes",
-            "url": reverse("admin:polls_vote_changelist")
-        },
-        {
-            "model": "polls.cheese", "name": "Cheeses",
-            "url": reverse("admin:polls_cheese_changelist")
-        },
-        {
-            "model": "polls.campaign", "name": "Campaigns",
-            "url": reverse("admin:polls_campaign_changelist")
-        },
-        {
-            "model": "polls.allfields", "name": "Allfields",
-            "url": reverse("admin:polls_allfields_changelist")
-        },
+        {"model": "polls.poll", "name": "Polls", "url": reverse("admin:polls_poll_changelist")},
+        {"model": "polls.choice", "name": "Choices", "url": reverse("admin:polls_choice_changelist")},
+        {"model": "polls.vote", "name": "Votes", "url": reverse("admin:polls_vote_changelist")},
+        {"model": "polls.cheese", "name": "Cheeses", "url": reverse("admin:polls_cheese_changelist")},
+        {"model": "polls.campaign", "name": "Campaigns", "url": reverse("admin:polls_campaign_changelist")},
+        {"model": "polls.allfields", "name": "Allfields", "url": reverse("admin:polls_allfields_changelist")},
     ]
 
     assert get_app_admin_urls("nothing") == []
@@ -106,5 +89,17 @@ def test_get_model_permissions():
     """
 
     user = user_with_permissions("polls.view_poll", "polls.view_choice")
+
+    assert get_view_permissions(user) == {"polls.poll", "polls.choice"}
+
+
+@pytest.mark.django_db
+def test_get_model_permissions_lowercased():
+    """
+    When our permissions are upper cased (we had an app with an upper case letter) we still get user perms in lower case
+    """
+
+    user = user_with_permissions("polls.view_poll", "polls.view_choice")
+    user.user_permissions.update(codename=Upper("codename"))
 
     assert get_view_permissions(user) == {"polls.poll", "polls.choice"}


### PR DESCRIPTION
Because we lower case app names during menu creation, but didnt lower case permission codenames, apps with upper case letters in their name would not be rendered out.

This is an oversight, and is fixed by this PR :)

Fixes https://github.com/farridav/django-jazzmin/issues/99 

Thanks for spotting this @navi380