### PR TITLE
Support for reversing URLs when multiple admins are being used

### DIFF
--- a/jazzmin/templates/admin/base.html
+++ b/jazzmin/templates/admin/base.html
@@ -122,7 +122,7 @@
                         {% endfor %}
                         <div class="dropdown-divider"></div>
                         {% if perms|can_view_self %}
-                            <a href="{{ request.user|jazzy_admin_url }}" class="dropdown-item dropdown-footer">{% trans 'See Profile' %}</a>
+                            <a href="{% jazzy_admin_url request.user request.current_app|default:"admin" %}" class="dropdown-item dropdown-footer">{% trans 'See Profile' %}</a>
                         {% endif %}
                     </div>
                 </li>
@@ -149,7 +149,7 @@
                         </div>
                         <div class="info">
                             {% if perms|can_view_self %}
-                                <a href="{{ request.user|jazzy_admin_url }}" class="d-block">{{ request.user }}</a>
+                                <a href="{% jazzy_admin_url request.user request.current_app|default:"admin" %}" class="d-block">{{ request.user }}</a>
                             {% else %}
                                 <span class="d-block" style="color: white;">{{ request.user }}</span>
                             {% endif %}

--- a/jazzmin/templates/admin/object_history.html
+++ b/jazzmin/templates/admin/object_history.html
@@ -39,7 +39,7 @@
                                     <i class="fas fa-{{ action_message|get_action_icon }} bg-{{ action_message|get_action_color }}"></i>
                                     <div class="timeline-item">
                                       <h3 class="timeline-header no-border">
-                                          <a href="{{ action.user|jazzy_admin_url }}" target="_blank">
+                                          <a href="{% jazzy_admin_url action.user request.current_app|default:"admin" %}" target="_blank">
                                               {{ action.user.get_username }}{% if action.user.get_full_name %} ({{ action.user.get_full_name }}){% endif %}
                                           </a>
                                           {{ action_message|style_bold_first_word }}

--- a/jazzmin/templatetags/jazzmin.py
+++ b/jazzmin/templatetags/jazzmin.py
@@ -224,12 +224,12 @@ def jazzmin_list_filter(cl, spec):
     return tpl.render({"field_name": field_key, "title": spec.title, "choices": choices, "spec": spec,})
 
 
-@register.filter
-def jazzy_admin_url(value):
+@register.simple_tag
+def jazzy_admin_url(value, admin_site="admin"):
     """
     Get the admin url for a given object
     """
-    return get_admin_url(value)
+    return get_admin_url(value, admin_site=admin_site)
 
 
 @register.filter

--- a/jazzmin/utils.py
+++ b/jazzmin/utils.py
@@ -52,7 +52,7 @@ def get_admin_url(instance, admin_site="admin", **kwargs):
         elif instance.__class__.__class__ == ModelBase and isinstance(instance, instance.__class__):
             app_label, model_name = instance._meta.app_label, instance._meta.model_name
             url = reverse(
-                "admin:{app_label}_{model_name}_change".format(admin_site, app_label=app_label, model_name=model_name),
+                "admin:{app_label}_{model_name}_change".format(app_label=app_label, model_name=model_name),
                 args=(instance.pk,),
                 current_app=admin_site
             )

--- a/jazzmin/utils.py
+++ b/jazzmin/utils.py
@@ -25,7 +25,7 @@ def order_with_respect_to(first, reference):
     return [y for x, y in sorted(zip(ranking, first), key=lambda x: x[0])]
 
 
-def get_admin_url(instance, **kwargs):
+def get_admin_url(instance, admin_site="admin", **kwargs):
     """
     Return the admin URL for the given instance, model class or <app>.<model> string
     """
@@ -36,22 +36,25 @@ def get_admin_url(instance, **kwargs):
         if type(instance) == str:
             app_label, model_name = instance.lower().split(".")
             url = reverse(
-                "admin:{app_label}_{model_name}_changelist".format(app_label=app_label, model_name=model_name)
+                "admin:{app_label}_{model_name}_changelist".format(app_label=app_label, model_name=model_name),
+                current_app=admin_site
             )
 
         # Model class
         elif instance.__class__ == ModelBase:
             app_label, model_name = instance._meta.app_label, instance._meta.model_name
             url = reverse(
-                "admin:{app_label}_{model_name}_changelist".format(app_label=app_label, model_name=model_name)
+                "admin:{app_label}_{model_name}_changelist".format(app_label=app_label, model_name=model_name),
+                current_app=admin_site
             )
 
         # Model instance
         elif instance.__class__.__class__ == ModelBase and isinstance(instance, instance.__class__):
             app_label, model_name = instance._meta.app_label, instance._meta.model_name
             url = reverse(
-                "admin:{app_label}_{model_name}_change".format(app_label=app_label, model_name=model_name),
+                "admin:{app_label}_{model_name}_change".format(admin_site, app_label=app_label, model_name=model_name),
                 args=(instance.pk,),
+                current_app=admin_site
             )
 
     except (NoReverseMatch, ValueError):


### PR DESCRIPTION
If multiple admin sites are installed, then Jazzmin's URL reverse code would only point to the default admin. This fixes those URLs thus supporting multiple admin sites.