### PR TITLE
Fixed bug that some icons cannot be displayed

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,7 +81,7 @@ JAZZMIN_SETTINGS = {
         'polls': [{
             'name': 'Make Messages', 
             'url': 'make_messages', 
-            'icon': 'fa-comments',
+            'icon': 'fas fa-comments',
             'permissions': ['polls.view_poll']
         }]
     },
@@ -89,13 +89,13 @@ JAZZMIN_SETTINGS = {
     # Custom icons for side menu apps/models See https://www.fontawesomecheatsheet.com/font-awesome-cheatsheet-5x/
     # for a list of icon classes
     'icons': {
-        'auth': 'fa-users-cog',
-        'auth.user': 'fa-user',
-        'auth.Group': 'fa-users',
+        'auth': 'fas fa-users-cog',
+        'auth.user': 'fas fa-user',
+        'auth.Group': 'fas fa-users',
     },
     # Icons that are used when one is not manually specified
-    'default_icon_parents': 'fa-chevron-circle-right',
-    'default_icon_children': 'fa-circle',
+    'default_icon_parents': 'fas fa-chevron-circle-right',
+    'default_icon_children': 'fas fa-circle',
 
     #############
     # UI Tweaks #
@@ -169,7 +169,7 @@ Example:
             'url': 'make_messages',                 
             
             # any font-awesome icon, see list here https://www.fontawesomecheatsheet.com/font-awesome-cheatsheet-5x/ (optional)
-            'icon': 'fa-comments',                  
+            'icon': 'fas fa-comments',                  
             
             # a list of permissions the user must have to see this link (optional)
             'permissions': ['polls.view_poll']     

--- a/jazzmin/settings.py
+++ b/jazzmin/settings.py
@@ -47,10 +47,10 @@ DEFAULT_SETTINGS = {
     "custom_links": {},
     # Custom icons for side menu apps/models See https://www.fontawesomecheatsheet.com/font-awesome-cheatsheet-5x/
     # for a list of icon classes
-    "icons": {"auth": "fa-users-cog", "auth.user": "fa-user", "auth.Group": "fa-users",},
+    "icons": {"auth": "fas fa-users-cog", "auth.user": "fas fa-user", "auth.Group": "fas fa-users",},
     # Icons that are used when one is not manually specified
-    "default_icon_parents": "fa-chevron-circle-right",
-    "default_icon_children": "fa-circle",
+    "default_icon_parents": "fas fa-chevron-circle-right",
+    "default_icon_children": "fas fa-circle",
     #############
     # UI Tweaks #
     #############

--- a/jazzmin/templates/admin/base.html
+++ b/jazzmin/templates/admin/base.html
@@ -117,7 +117,7 @@
                         {% for link in user_menu %}
                             <div class="dropdown-divider"></div>
                             <a href="{{ link.url }}" class="dropdown-item" {% if link.new_window %}target="_blank"{% endif %}>
-                                <i class="fas {{ link.icon }} mr-2"></i> {% trans link.name %}
+                                <i class="{{ link.icon }} mr-2"></i> {% trans link.name %}
                             </a>
                         {% endfor %}
                         <div class="dropdown-divider"></div>
@@ -172,7 +172,7 @@
                                     {% for model in app.models %}
                                         <li class="nav-item">
                                             <a href="{% if model.url %}{{ model.url }}{% else %}javascript:void(0){% endif %}" class="nav-link">
-                                                <i class="fa nav-icon {{ model.icon }}"></i>
+                                                <i class="nav-icon {{ model.icon }}"></i>
                                                 <p>{{ model.name }}</p>
                                             </a>
                                         </li>
@@ -182,14 +182,14 @@
                                 {% for app in side_menu_list %}
                                     <li class="nav-item has-treeview">
                                         <a href="#" class="nav-link">
-                                            <i class="nav-icon fas {{ app.icon }}"></i>
+                                            <i class="nav-icon {{ app.icon }}"></i>
                                             <p>{{ app.name|truncatechars:21 }} <i class="fas fa-angle-left right"></i></p>
                                         </a>
                                         <ul class="nav nav-treeview" style="display: none;">
                                             {% for model in app.models %}
                                                 <li class="nav-item">
                                                     <a href="{% if model.url %}{{ model.url }}{% else %}javascript:void(0){% endif %}" class="nav-link">
-                                                        <i class="fa nav-icon {{ model.icon }}"></i>
+                                                        <i class="nav-icon {{ model.icon }}"></i>
                                                         <p>{{ model.name }}</p>
                                                     </a>
                                                 </li>


### PR DESCRIPTION
Not all Font Awesome 5.X icons use the "fas" class, and some icons use the "far" or "fab" class such as `<i class="fab fa-apple"></i>`. If developers need to customize  icons, I think they should be allowed to configure the full classes of the icon. At the same time, developers can also use other icon libraries more safely without being affected by "fas" or "fa".