### PR TITLE
Adjust permissions to cater for users with view or change

### DIFF
--- a/jazzmin/templates/admin/base.html
+++ b/jazzmin/templates/admin/base.html
@@ -171,10 +171,15 @@
                                     <li class="nav-header">{{ app.name }}</li>
                                     {% for model in app.models %}
                                         <li class="nav-item">
-                                            <a href="{% if model.url %}{{ model.url }}{% else %}javascript:void(0){% endif %}" class="nav-link">
-                                                <i class="nav-icon {{ model.icon }}"></i>
-                                                <p>{{ model.name }}</p>
+                                            {% if model.url %}
+                                            <a href="{{ model.url }}" class="nav-link">
+                                                <i class="nav-icon {{ model.icon }}"></i> <p>{{ model.name }}</p>
                                             </a>
+                                        {% else %}
+                                            <span class="nav-link disabled">
+                                                <i class="nav-icon {{ model.icon }}"></i> <p>{{ model.name }}</p>
+                                            </span>
+                                        {% endif %}
                                         </li>
                                     {% endfor %}
                                 {% endfor %}

--- a/jazzmin/templatetags/jazzmin.py
+++ b/jazzmin/templatetags/jazzmin.py
@@ -38,6 +38,8 @@ logger = logging.getLogger(__name__)
 def get_side_menu(context):
     """
     Get the list of apps and models to render out in the side menu and on the dashboard page
+
+    N.B - Permissions are not checked here, as context["available_apps"] has already been filtered by django
     """
 
     user = context.get("user")

--- a/jazzmin/templatetags/jazzmin.py
+++ b/jazzmin/templatetags/jazzmin.py
@@ -25,7 +25,6 @@ from ..utils import (
     order_with_respect_to,
     get_filter_id,
     get_admin_url,
-    get_view_permissions,
     make_menu,
     has_fieldsets_check,
 )
@@ -45,7 +44,6 @@ def get_side_menu(context):
     if not user:
         return []
 
-    model_permissions = get_view_permissions(user)
     options = get_settings()
 
     menu = []
@@ -64,8 +62,6 @@ def get_side_menu(context):
         menu_items = []
         for model in app.get("models", []):
             model_str = "{app_label}.{model}".format(app_label=app_label, model=model["object_name"]).lower()
-            if model_str not in model_permissions:
-                continue
             if model_str in options.get("hide_models", []):
                 continue
 

--- a/jazzmin/utils.py
+++ b/jazzmin/utils.py
@@ -37,7 +37,7 @@ def get_admin_url(instance, admin_site="admin", **kwargs):
             app_label, model_name = instance.lower().split(".")
             url = reverse(
                 "admin:{app_label}_{model_name}_changelist".format(app_label=app_label, model_name=model_name),
-                current_app=admin_site
+                current_app=admin_site,
             )
 
         # Model class
@@ -45,7 +45,7 @@ def get_admin_url(instance, admin_site="admin", **kwargs):
             app_label, model_name = instance._meta.app_label, instance._meta.model_name
             url = reverse(
                 "admin:{app_label}_{model_name}_changelist".format(app_label=app_label, model_name=model_name),
-                current_app=admin_site
+                current_app=admin_site,
             )
 
         # Model instance
@@ -54,11 +54,11 @@ def get_admin_url(instance, admin_site="admin", **kwargs):
             url = reverse(
                 "admin:{app_label}_{model_name}_change".format(app_label=app_label, model_name=model_name),
                 args=(instance.pk,),
-                current_app=admin_site
+                current_app=admin_site,
             )
 
     except (NoReverseMatch, ValueError):
-        logger.error("Couldnt reverse url from {instance}".format(instance=instance))
+        logger.warning("Couldnt reverse url from {instance}".format(instance=instance))
 
     if kwargs:
         url += "?{params}".format(params=urlencode(kwargs))
@@ -130,10 +130,10 @@ def get_app_admin_urls(app):
 
 def get_view_permissions(user):
     """
-    Get model names based on a users view permissions
+    Get model names based on a users view/change permissions
     """
     lower_perms = map(lambda x: x.lower(), user.get_all_permissions())
-    return {x.replace("view_", "") for x in lower_perms if "view" in x}
+    return {x.replace("view_", "") for x in lower_perms if "view" in x or "change" in x}
 
 
 def make_menu(user, links, options, allow_appmenus=True):
@@ -186,7 +186,7 @@ def make_menu(user, links, options, allow_appmenus=True):
         # App links
         elif "app" in link and allow_appmenus:
             children = [
-                {"name": child.get("verbose_name", child["name"]), "url": child["url"], "children": None}
+                {"name": child.get("verbose_name", child["name"]), "url": child["url"], "children": None,}
                 for child in get_app_admin_urls(link["app"])
                 if child["model"] in model_permissions
             ]

--- a/jazzmin/widgets.py
+++ b/jazzmin/widgets.py
@@ -8,7 +8,7 @@ class JazzminSelect(Select):
     @property
     def media(self):
         return forms.Media(
-            css={"all": ("adminlte/plugins/select2/select2.min.css",)}, js=("adminlte/plugins/select2/select2.min.js",)
+            css={"all": ("adminlte/plugins/select2/select2.min.css",)}, js=("adminlte/plugins/select2/select2.min.js",),
         )
 
 
@@ -22,5 +22,5 @@ class JazzminSelectMultiple(SelectMultiple):
     @property
     def media(self):
         return forms.Media(
-            css={"all": ("adminlte/plugins/select2/select2.min.css",)}, js=("adminlte/plugins/select2/select2.min.js",)
+            css={"all": ("adminlte/plugins/select2/select2.min.css",)}, js=("adminlte/plugins/select2/select2.min.js",),
         )

--- a/tests/test_app/settings.py
+++ b/tests/test_app/settings.py
@@ -151,7 +151,12 @@ JAZZMIN_SETTINGS = {
     # Custom links to append to app groups, keyed on app name
     "custom_links": {
         "polls": [
-            {"name": "Make Messages", "url": "make_messages", "icon": "fas fa-comments", "permissions": ["polls.view_poll"]}
+            {
+                "name": "Make Messages",
+                "url": "make_messages",
+                "icon": "fas fa-comments",
+                "permissions": ["polls.view_poll"],
+            }
         ]
     },
     # Custom icons for side menu apps/models See https://www.fontawesomecheatsheet.com/font-awesome-cheatsheet-5x/

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -37,23 +37,27 @@ def test_no_add_permission(client):
 
 
 @pytest.mark.django_db
-def test_no_view_permission(client):
+def test_delete_but_no_view_permission(client):
     """
-    When our user has no view permission, they dont see things they are not supposed to
+    When our user has delete but no view/change permission, menu items render out, but with no links
+
+    As in Plain old Django Admin
     """
-    user = user_with_permissions("polls.change_poll")
+    user = user_with_permissions("polls.delete_poll")
 
     url = reverse("admin:index")
     client.force_login(user)
 
     response = client.get(url)
-    assert parse_sidemenu(response) == {"Global": ["/admin/"]}
+    assert parse_sidemenu(response) == {"Global": ['/admin/'], 'Polls': [None]}
 
 
 @pytest.mark.django_db
 def test_no_permission(client):
     """
     When our user has no permissions at all, they see no menu or dashboard
+
+    As in Plain old Django Admin
     """
     user = user_with_permissions()
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -51,8 +51,8 @@ def parse_sidemenu(response):
             current_app = li.text.strip()
 
         elif "nav-item" in li["class"]:
-            href = li.find("a")["href"]
-            menu[current_app].append(href)
+            href = li.find("a")
+            menu[current_app].append(href["href"] if href else None)
 
     return menu
 


### PR DESCRIPTION
Updates on @fengyouchao s PR (https://github.com/farridav/django-jazzmin/pull/111)

- Fix up No view test 
_Change to user with delete, but no view/change permission_

- When no model admin link available, disable menu link
_Use a span class instead, behaviour mimics original admin_
- Run black over files
- Change error log to warning
- Adjust `get_view_permissions` to look for view or change, to ensure links in other menus are generated appropriately (mimics original admin)

Fixes #110 