### PR TITLE
Remove app.css from password_change_form.html

### DIFF
--- a/jazzmin/templates/registration/password_change_form.html
+++ b/jazzmin/templates/registration/password_change_form.html
@@ -2,7 +2,6 @@
 {% load i18n static %}
 {% block extrastyle %}
 {{ block.super }}
-<link rel="stylesheet" href="{% static "jazzmin/css/app.css" %}">
 {% endblock %}
 
 {# TODO: This should come through somewhere, also admin docs :( #}


### PR DESCRIPTION
jazzmin/css/app.css was removed at some point, but still exists in the password change form which crashes the app.