### PR TITLE
The last inline in a TabularInline is empty and should be hidden

### DIFF
--- a/jazzmin/templates/admin/edit_inline/tabular.html
+++ b/jazzmin/templates/admin/edit_inline/tabular.html
@@ -31,7 +31,7 @@
                         </td>
                     </tr>
                     {% endif %}
-                    <tr id="{{ inline_admin_formset.formset.prefix }}-{% if not forloop.last %}{{ forloop.counter0 }}{% else %}empty{% endif %}">
+                    <tr id="{{ inline_admin_formset.formset.prefix }}-{% if not forloop.last %}{{ forloop.counter0 }}{% else %}empty{% endif %}"{% if forloop.last %} class="empty-form"{% endif %}>
                         <td class="original">
                             {% if inline_admin_form.original or inline_admin_form.show_url %}<p>
                                 {% if inline_admin_form.original %}


### PR DESCRIPTION
The empty-form class was missing from the last inline in the Tabular inline template which should be hidden. This is not a problem in the Stacked inline template.