### PR TITLE
Fixing incorrect css/js paths in the JazzminSelect widgets

### DIFF
--- a/jazzmin/widgets.py
+++ b/jazzmin/widgets.py
@@ -8,7 +8,8 @@ class JazzminSelect(Select):
     @property
     def media(self):
         return forms.Media(
-            css={"all": ("adminlte/plugins/select2/css/select2.min.css",)}, js=("adminlte/plugins/select2/js/select2.min.js",),
+            css={"all": ("adminlte/plugins/select2/css/select2.min.css",)},
+            js=("adminlte/plugins/select2/js/select2.min.js",),
         )
 
 
@@ -22,5 +23,6 @@ class JazzminSelectMultiple(SelectMultiple):
     @property
     def media(self):
         return forms.Media(
-            css={"all": ("adminlte/plugins/select2/css/select2.min.css",)}, js=("adminlte/plugins/select2/js/select2.min.js",),
+            css={"all": ("adminlte/plugins/select2/css/select2.min.css",)},
+            js=("adminlte/plugins/select2/js/select2.min.js",),
         )

--- a/jazzmin/widgets.py
+++ b/jazzmin/widgets.py
@@ -8,7 +8,7 @@ class JazzminSelect(Select):
     @property
     def media(self):
         return forms.Media(
-            css={"all": ("adminlte/plugins/select2/select2.min.css",)}, js=("adminlte/plugins/select2/select2.min.js",),
+            css={"all": ("adminlte/plugins/select2/css/select2.min.css",)}, js=("adminlte/plugins/select2/js/select2.min.js",),
         )
 
 
@@ -22,5 +22,5 @@ class JazzminSelectMultiple(SelectMultiple):
     @property
     def media(self):
         return forms.Media(
-            css={"all": ("adminlte/plugins/select2/select2.min.css",)}, js=("adminlte/plugins/select2/select2.min.js",),
+            css={"all": ("adminlte/plugins/select2/css/select2.min.css",)}, js=("adminlte/plugins/select2/js/select2.min.js",),
         )


### PR DESCRIPTION
The css & js paths were incorrect, so the widget didn't change it's look.