### PR TITLE
Improving the inline admin formset

### DIFF
--- a/jazzmin/static/jazzmin/css/django.css
+++ b/jazzmin/static/jazzmin/css/django.css
@@ -64,7 +64,7 @@ tr.djn-tr > .original {
 }
 
 .related-widget-wrapper select {
-    width: 90%;
+    width: initial; /* Setting a width will make the *-related btns overflow */
     height: auto;
     padding: .375rem .75rem;
     font-size: 1rem;
@@ -425,6 +425,13 @@ table.dataTable thead .sorting_desc_disabled::after {
     padding: 0;
     overflow: hidden;
     line-height: 1;
+}
+
+/* Might need to import more rules from:
+ * https://github.com/django/django/blob/master/django/contrib/admin/static/admin/css/responsive.css
+ */
+.inline-group {
+    overflow: auto;
 }
 
 .selector .selector-available input {


### PR DESCRIPTION
There are some issues with the inline admin formset, as can be seen in this picture. 

 * The *-related buttons are overflown to other elements 
 * When the page cannot contain the inline formset, it overflows the box, instead of setting a scroll bar as in the original admin page. 

This PR sets some CSS to resolve this.

![Borked admin inline formset](https://i.imgur.com/VY91wRc.png)