### PR TITLE
Temporarily use JS to stop height bug

### DIFF
--- a/jazzmin/static/jazzmin/js/change_form.js
+++ b/jazzmin/static/jazzmin/js/change_form.js
@@ -81,10 +81,14 @@ function handleCollapsible($collapsible) {
 $(document).ready(function () {
     const $carousel = $('#content-main form #jazzy-carousel');
     const $tabs = $('#content-main form #jazzy-tabs');
-    const $collapsible = $('#content-main form #jazzy-collapsible');
+
+    // Stop the height being set to 1px during a JS race condition
+    // TODO: Find the JS that is setting this html attribute, and solve the problem properly
+    $('.selector .selector-chosen select').removeAttr('style');
 
     // Ensure all raw_id_fields have the search icon in them
-    $('.related-lookup').append('<i class="fa fa-search"></i>')
+    const $collapsible = $('#content-main form #jazzy-collapsible');
+    $('.related-lookup').append('<i class="fa fa-search"></i>');
 
     // Style the inline fieldset button
     $('.inline-related fieldset.module .add-row a').addClass('btn btn-sm btn-default float-right');
@@ -94,4 +98,3 @@ $(document).ready(function () {
     else if ($carousel.length) {handleCarousel($carousel);}
     else if ($collapsible.length) {handleCollapsible($collapsible);}
 });
-


### PR DESCRIPTION
It seems there is some javascript that is dynamically setting the height of multi select boxes, and in some race conditions, it sets the height to 1px (presumably because the JS that does this runs before the JS that populates the box)

I don't think this is happening in any of the JS in jazzmin, but our markup or CSS is obviously playing some part in the race condition. 

This is a tricky one to find and fix, as it doesnt occur locally, and requires deeper digging, probably re-working of the select multi select (which we have wanted to do for a while now)

This plaster on top is hopefully temporary, if anyone wants to take a stab at this properly, feel free, ideally without moving too far into custom CSS/JS/HTML territory, as that adds to the cost of maintenance.

Hot fixes https://github.com/farridav/django-jazzmin/issues/129

