### PR TITLE
Fixed #133: inline radio button to respect admin.VERTICAL and admin.HORIZONTAL

### DIFF
--- a/jazzmin/static/jazzmin/css/django.css
+++ b/jazzmin/static/jazzmin/css/django.css
@@ -683,3 +683,4 @@ form ul.inline {
 form ul.inline li {
     float: left;
     padding-right: 7px;
+}

--- a/jazzmin/static/jazzmin/css/django.css
+++ b/jazzmin/static/jazzmin/css/django.css
@@ -660,3 +660,26 @@ body.no-sidebar .main-header {
 #jazzy-carousel .carousel-indicators {
     position: initial;
 }
+
+form ul.radiolist li {
+    list-style-type: none;
+}
+
+form ul.radiolist label {
+    float: none;
+    display: inline;
+}
+
+form ul.radiolist input[type="radio"] {
+    margin: -2px 4px 0 0;
+    padding: 0;
+}
+
+form ul.inline {
+    margin-left: 0;
+    padding: 0;
+}
+
+form ul.inline li {
+    float: left;
+    padding-right: 7px;


### PR DESCRIPTION
Before: Both `admin.HORIZONTZAL` and `admin.VERTICAL`:
![image](https://user-images.githubusercontent.com/14917071/91637687-22a08200-ea02-11ea-873e-56bf4992585c.png)
Now: `admin.HORIZONTAL`
![image](https://user-images.githubusercontent.com/14917071/91637713-495eb880-ea02-11ea-9dc8-08a0330ad846.png)
`admin.VERTICAL`
![image](https://user-images.githubusercontent.com/14917071/91637767-ace8e600-ea02-11ea-9da3-65a3a0c41eb8.png)
