### PR TITLE
Add custom css js to login and logged_out pages.

### DIFF
--- a/jazzmin/templates/admin/login.html
+++ b/jazzmin/templates/admin/login.html
@@ -18,6 +18,10 @@
     <!-- Custom fixes for django -->
     <link rel="stylesheet" href="{% static "jazzmin/css/django.css" %}">
 
+    {% if jazzmin_settings.custom_css %}
+        <link rel="stylesheet" href="{% static jazzmin_settings.custom_css %}">
+    {% endif %}
+
     <!-- Google Font: Source Sans Pro -->
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700" rel="stylesheet">
     {% block extrastyle %} {% endblock %}
@@ -95,6 +99,10 @@
 <script src="{% static 'adminlte/plugins/bootstrap/js/bootstrap.bundle.min.js' %}"></script>
 <!-- AdminLTE App -->
 <script src="{% static 'adminlte/js/adminlte.min.js' %}"></script>
+
+{% if jazzmin_settings.custom_js %}
+<script src="{% static jazzmin_settings.custom_js %}"></script>
+{% endif %}
 
 </body>
 </html>

--- a/jazzmin/templates/registration/logged_out.html
+++ b/jazzmin/templates/registration/logged_out.html
@@ -19,6 +19,10 @@
     <!-- Theme style -->
     <link rel="stylesheet" href={% static "adminlte/css/adminlte.min.css" %}>
 
+    {% if jazzmin_settings.custom_css %}
+        <link rel="stylesheet" href="{% static jazzmin_settings.custom_css %}">
+    {% endif %}
+
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>
@@ -42,6 +46,10 @@
         </p>
     </div>
 </div>
+
+{% if jazzmin_settings.custom_js %}
+<script src="{% static jazzmin_settings.custom_js %}"></script>
+{% endif %}
 
 </body>
 </html>


### PR DESCRIPTION
The custom_css and custom_js files should also be added to the login.html and logged_out.html pages as otherwise there is no way to add customized css and js to those pages. 

This PR adds those links in the same way as they are added to the base.html. 