### PR TITLE
fix: Remove title filter

### DIFF
--- a/jazzmin/templates/jazzmin/includes/carousel.html
+++ b/jazzmin/templates/jazzmin/includes/carousel.html
@@ -7,7 +7,7 @@
         </div>
         <div class="col-sm-8 text-center">
             <p class="carousel-fieldset-label">
-                {{ adminform.fieldsets.0.0|default:"General"|title }}
+                {{ adminform.fieldsets.0.0|default:"General" }}
             </p>
         </div>
         <div class="col-sm-2">

--- a/jazzmin/templates/jazzmin/includes/collapsible.html
+++ b/jazzmin/templates/jazzmin/includes/collapsible.html
@@ -5,7 +5,7 @@
         <div class="card card-default">
             <div class="card-header collapsible-header" data-toggle="collapse" data-parent="#jazzy-collapsible" data-target="#{{ fieldset.name|default:"General"|unicode_slugify }}-tab">
                 <h4 class="card-title">
-                    {{ fieldset.name|default:"General"|title }}
+                    {{ fieldset.name|default:"General" }}
                 </h4>
             </div>
             <div id="{{ fieldset.name|default:"General"|unicode_slugify }}-tab" class="panel-collapse in {% if forloop.first %}show{% else %}collapse{% endif %}">

--- a/jazzmin/templates/jazzmin/includes/horizontal_tabs.html
+++ b/jazzmin/templates/jazzmin/includes/horizontal_tabs.html
@@ -4,7 +4,7 @@
     {% for fieldset in adminform %}
         <li class="nav-item">
             <a class="nav-link{% if forloop.first %} active{% endif %}" data-toggle="pill" role="tab" aria-controls="{{ fieldset.name|default:"General"|unicode_slugify }}-tab" aria-selected="{% if forloop.first %}true{% else %}false{% endif %}" href="#{{ fieldset.name|default:"General"|unicode_slugify }}-tab">
-                {{ fieldset.name|default:"General"|title }}
+                {{ fieldset.name|default:"General" }}
             </a>
         </li>
     {% endfor %}

--- a/jazzmin/templates/jazzmin/includes/vertical_tabs.html
+++ b/jazzmin/templates/jazzmin/includes/vertical_tabs.html
@@ -5,7 +5,7 @@
         <div class="nav flex-column nav-tabs h-100" role="tablist" aria-orientation="vertical">
             {% for fieldset in adminform %}
                 <a class="nav-link {% if forloop.first %}active{% endif %}" data-toggle="pill" href="#{{ fieldset.name|default:"General"|unicode_slugify }}-tab" role="tab" aria-controls="{{ fieldset.name|default:"General"|unicode_slugify }}-tab" aria-selected="{% if forloop.first %}true{% else %}false{% endif %}">
-                    {{ fieldset.name|default:"General"|title }}
+                    {{ fieldset.name|default:"General" }}
                 </a>
             {% endfor %}
             {% for inline_admin_formset in inline_admin_formsets %}


### PR DESCRIPTION
The `fieldset.name` should be displayed directly without `title` filter. If  `title` filter is used, it will cause some inappropriate changes. For example, "iOS Opitions" will be changed to "Ios Options".