### PR TITLE
Add app index and fix breadcrumb in change list

### DIFF
--- a/jazzmin/templates/admin/app_index.html
+++ b/jazzmin/templates/admin/app_index.html
@@ -1,0 +1,15 @@
+{% extends "admin/index.html" %}
+{% load i18n %}
+
+{% block bodyclass %}{{ block.super }} app-{{ app_label }}{% endblock %}
+
+{% if not is_popup %}
+    {% block breadcrumbs %}
+        <ol class="breadcrumb float-sm-right">
+            <li class="breadcrumb-item"><a href="{% url 'admin:index' %}"><i class="fa fa-tachometer-alt"></i> {% trans 'Home' %}</a></li>
+            <li class="breadcrumb-item">{% for app in app_list %}{{ app.name }}{% endfor %}</li>
+        </ol>
+    {% endblock %}
+{% endif %}
+
+{% block sidebar %}{% endblock %}

--- a/jazzmin/templates/admin/app_index.html
+++ b/jazzmin/templates/admin/app_index.html
@@ -1,6 +1,8 @@
 {% extends "admin/index.html" %}
 {% load i18n %}
 
+{% block content_title %} {{ app_label|capfirst }} {% endblock %}
+
 {% block bodyclass %}{{ block.super }} app-{{ app_label }}{% endblock %}
 
 {% if not is_popup %}
@@ -11,5 +13,3 @@
         </ol>
     {% endblock %}
 {% endif %}
-
-{% block sidebar %}{% endblock %}

--- a/jazzmin/templates/admin/change_list.html
+++ b/jazzmin/templates/admin/change_list.html
@@ -27,7 +27,7 @@
     {% block breadcrumbs %}
         <ol class="breadcrumb float-sm-right">
             <li class="breadcrumb-item"><a href="{% url 'admin:index' %}"><i class="fa fa-tachometer-alt"></i> {% trans 'Home' %}</a></li>
-            <li class="breadcrumb-item"><a href="javascript:void(0)">{{ cl.opts.app_config.verbose_name }}</a></li>
+            <li class="breadcrumb-item"><a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a></li>
             <li class="breadcrumb-item active">{{ cl.opts.verbose_name_plural|capfirst }}</li>
         </ol>
     {% endblock %}

--- a/jazzmin/templates/admin/index.html
+++ b/jazzmin/templates/admin/index.html
@@ -14,7 +14,7 @@
 
 
 {% block content %}
-    {% get_side_menu as dashboard_list %}
+    {% get_side_menu using="app_list" as dashboard_list %}
     {% if dashboard_list %}
         {% widthratio dashboard_list|length 2 1 as middle %}
     {% endif %}

--- a/jazzmin/templatetags/jazzmin.py
+++ b/jazzmin/templatetags/jazzmin.py
@@ -35,13 +35,12 @@ logger = logging.getLogger(__name__)
 
 
 @register.simple_tag(takes_context=True)
-def get_side_menu(context):
+def get_side_menu(context, using="available_apps"):
     """
     Get the list of apps and models to render out in the side menu and on the dashboard page
 
     N.B - Permissions are not checked here, as context["available_apps"] has already been filtered by django
     """
-
     user = context.get("user")
     if not user:
         return []
@@ -49,7 +48,8 @@ def get_side_menu(context):
     options = get_settings()
 
     menu = []
-    available_apps = copy.deepcopy(context.get("available_apps", []))
+    available_apps = copy.deepcopy(context.get(using, []))
+
     custom_links = {
         app_name: make_menu(user, links, options, allow_appmenus=False)
         for app_name, links in options.get("custom_links", {}).items()
@@ -84,7 +84,7 @@ def get_side_menu(context):
 
 
 @register.simple_tag
-def get_top_menu(user, admin_site='admin'):
+def get_top_menu(user, admin_site="admin"):
     """
     Produce the menu for the top nav bar
     """
@@ -93,7 +93,7 @@ def get_top_menu(user, admin_site='admin'):
 
 
 @register.simple_tag
-def get_user_menu(user, admin_site='admin'):
+def get_user_menu(user, admin_site="admin"):
     """
     Produce the menu for the user dropdown
     """


### PR DESCRIPTION
This looks like an easy fix but it's becoming a bit tricky... The thing is, the second element (app element) for the breadcrumbs, visible when loading an object for example, is not pointing anywhere. The obvious solution that I found is that the template wasn't in jazzmin, but after adding the template, it was still missing the app list part and adding all apps instead..

Apparently, overriding that one is not that straightforward: https://stackoverflow.com/questions/41770603/how-do-you-override-djangos-admin-app-index

I leave this as food for thought, just in case you have an idea about it!