### PR TITLE
Reverse order in object history

### DIFF
--- a/jazzmin/templates/admin/object_history.html
+++ b/jazzmin/templates/admin/object_history.html
@@ -28,7 +28,7 @@
 
                         <div class="timeline">
 
-                            {% for action in action_list %}
+                            {% for action in action_list reversed %}
                               <div class="time-label">
                                 <span class="bg-info">{{ action.action_time|date:"DATETIME_FORMAT" }}</span>
                               </div>


### PR DESCRIPTION
- Order in object history is wrong. It should start from the bottom up

Example of current behaviour:
<img width="295" alt="Screenshot 2020-09-19 at 14 28 50" src="https://user-images.githubusercontent.com/22962693/93668497-7db71900-fa84-11ea-8523-8d28a75eb1ee.png">
