### PR TITLE
Allow ordering of models or custom links

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -73,8 +73,8 @@ JAZZMIN_SETTINGS = {
     # Hide these models when generating side menu (e.g auth.user)
     'hide_models': [],
 
-    # List of apps to base side menu ordering off of (does not need to contain all apps)
-    'order_with_respect_to': ['accounts', 'polls'],
+    # List of apps (and/or models) to base side menu ordering off of (does not need to contain all apps/models)
+    "order_with_respect_to": ["auth", "polls", "polls.choice", "polls.poll"],
 
     # Custom links to append to app groups, keyed on app name
     'custom_links': {
@@ -154,8 +154,33 @@ links to model admin pages.
 You can omit apps, or models from this generated menu, using `hide_apps` or `hide_models` where app is like `auth` and 
 model is like `auth.user`
 
-Ordering of the menu can be done using `order_with_respect_to`, which is a list of apps you want to base the ordering off 
-of, it can be a partial list 
+Ordering of the menu can be done using `order_with_respect_to`, which is a list of apps/models/custom links you want to 
+base  the ordering off of, it can be a full, or partial list, some examples:
+
+```
+# Order the auth app before the polls app, other apps will be alphabetically placed after these
+"order_with_respect_to": ["auth", "polls"],
+
+# Keep the same app ordering as above, but also order choice and poll model links within the polls app
+"order_with_respect_to": ["auth", "polls", "polls.choice", "polls.poll"],
+
+# Just make sure auth is first
+"order_with_respect_to": ["auth"],
+
+# Order apps automatically, but make sure choice and poll admin links are first within the polls app
+"order_with_respect_to": ["polls.choice", "polls.poll"],
+
+# Place our choice model admin link and our custom link first within the polls app (Note: custom link name used for order key)
+"order_with_respect_to": ["polls.choice", "Make Messages"],
+
+# do nothing
+"order_with_respect_to": [],
+
+# Still do nothing
+"order_with_respect_to": ["doesnt_exist"],
+```
+
+Currently, custom links (See below) cannot be ordered
 
 ### Side menu custom links
 

--- a/jazzmin/utils.py
+++ b/jazzmin/utils.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Union, Dict, Set
+from typing import List, Union, Dict, Set, Callable
 from urllib.parse import urlencode
 
 from django.apps import apps
@@ -15,19 +15,27 @@ from jazzmin.compat import NoReverseMatch, reverse
 logger = logging.getLogger(__name__)
 
 
-def order_with_respect_to(first: List, reference: List) -> List:
+def order_with_respect_to(original: List, reference: List, getter: Callable = None) -> List:
+    """
+    Order a list based on the location of items in the reference list, optionally, use a getter to pull values out of
+    the first list
+    """
     ranking = []
-    max_num = len(first)
+    max_num = len(original)
+    if not getter:
 
-    for item in first:
+        def getter(x):
+            return x
+
+    for item in original:
         try:
-            pos = reference.index(item["app_label"])
+            pos = reference.index(getter(item))
         except ValueError:
             pos = max_num
 
         ranking.append(pos)
 
-    return [y for x, y in sorted(zip(ranking, first), key=lambda x: x[0])]
+    return [y for x, y in sorted(zip(ranking, original), key=lambda x: x[0])]
 
 
 def get_admin_url(instance: Union[str, ModelBase], admin_site: str = "admin", **kwargs: str) -> str:

--- a/tests/test_app/settings.py
+++ b/tests/test_app/settings.py
@@ -160,8 +160,8 @@ JAZZMIN_SETTINGS = {
     "hide_apps": [],
     # Hide these models when generating side menu (e.g auth.user)
     "hide_models": [],
-    # List of apps to base side menu ordering off of
-    "order_with_respect_to": ["accounts", "polls"],
+    # List of apps to base side menu (app or model) ordering off of
+    "order_with_respect_to": ["Make Messages", "auth", "polls", "polls.choice", "polls.poll"],
     # Custom links to append to app groups, keyed on app name
     "custom_links": {
         "polls": [

--- a/tests/test_jazzmin_menus.py
+++ b/tests/test_jazzmin_menus.py
@@ -16,12 +16,12 @@ def test_side_menu(admin_client, settings):
     assert parse_sidemenu(response) == {
         "Global": ["/en/admin/"],
         "Polls": [
-            "/en/admin/polls/campaign/",
-            "/en/admin/polls/cheese/",
+            "/make_messages/",
             "/en/admin/polls/choice/",
             "/en/admin/polls/poll/",
+            "/en/admin/polls/campaign/",
+            "/en/admin/polls/cheese/",
             "/en/admin/polls/vote/",
-            "/make_messages/",
         ],
         "Administration": ["/en/admin/admin/logentry/"],
         "Authentication and Authorization": ["/en/admin/auth/group/", "/en/admin/auth/user/"],
@@ -33,12 +33,12 @@ def test_side_menu(admin_client, settings):
     assert parse_sidemenu(response) == {
         "Global": ["/en/admin/"],
         "Polls": [
-            "/en/admin/polls/campaign/",
-            "/en/admin/polls/cheese/",
+            "/make_messages/",
             "/en/admin/polls/choice/",
             "/en/admin/polls/poll/",
+            "/en/admin/polls/campaign/",
+            "/en/admin/polls/cheese/",
             "/en/admin/polls/vote/",
-            "/make_messages/",
         ],
         "Administration": ["/en/admin/admin/logentry/"],
         "Authentication and Authorization": ["/en/admin/auth/group/"],
@@ -74,7 +74,10 @@ def test_permissions_on_custom_links(client, settings):
 
     client.force_login(user2)
     response = client.get(url)
-    assert parse_sidemenu(response) == {"Global": ["/en/admin/"], "Polls": ["/en/admin/polls/poll/", "/make_messages/"]}
+    assert parse_sidemenu(response) == {
+        "Global": ["/en/admin/"],
+        "Polls": ["/make_messages/", "/en/admin/polls/poll/"],
+    }
 
 
 @pytest.mark.django_db

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,9 +24,12 @@ def test_order_with_respect_to():
 
     original_list = apps("b", "c", "a")
 
-    assert order_with_respect_to(original_list, ["c", "b"]) == apps("c", "b", "a")
-    assert order_with_respect_to(original_list, ["nothing"]) == original_list
-    assert order_with_respect_to(original_list, ["a"])[0]["app_label"] == "a"
+    assert order_with_respect_to(original_list, ["c", "b"], getter=lambda x: x["app_label"]) == apps("c", "b", "a")
+    assert order_with_respect_to(original_list, ["nothing"], getter=lambda x: x["app_label"]) == original_list
+    assert order_with_respect_to(original_list, ["a"], getter=lambda x: x["app_label"])[0]["app_label"] == "a"
+    assert order_with_respect_to([1, 2, 3], [3, 2, 1]) == [3, 2, 1]
+    assert order_with_respect_to([1, 2, 3], [3]) == [3, 1, 2]
+    assert order_with_respect_to(["morty", "pickle", "rick"], ["pickle", "morty"]) == ["pickle", "morty", "rick"]
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Allow ordering of apps/models or custom links using the `order_with_respect_to` setting

- Add examples
- Update docs
- Add tests

Fixes: https://github.com/farridav/django-jazzmin/issues/162
