### PR TITLE
(fix) capfirst for label

### DIFF
--- a/jazzmin/templates/admin/includes/fieldset.html
+++ b/jazzmin/templates/admin/includes/fieldset.html
@@ -9,7 +9,7 @@
         <div class="row">
             {% for field in line %}
                 <label class="{% if not line.fields|length_is:'1' and forloop.counter != 1 %}col-auto {% else %}col-sm-2 {% endif %}text-left">
-                    {{ field.field.label }}
+                    {{ field.field.label|capfirst }}
                     {% if field.field.field.required %}
                     <span class="text-red">* </span>
                     {% endif %}


### PR DESCRIPTION
If label of models field in lowercase and this field set as readonly in admin, then this label was lowercase in admin.