### PR TITLE
tabs improve style

### DIFF
--- a/jazzmin/static/jazzmin/css/django.css
+++ b/jazzmin/static/jazzmin/css/django.css
@@ -690,17 +690,19 @@ form ul.inline li {
 
 /* stacked inlines */
 a.inline-deletelink:hover {
-    border: 1px solid darkred;
+    background-color: #c82333;
+    border-color: #bd2130;
 }
 
 a.inline-deletelink {
     float: right;
     padding: 3px 5px;
     margin: 10px;
-    background-color: red;
-    border-radius: 7px;
+    background-color: #dc3545;
+    border-radius: .25rem;
     color: white !important;
-    border: 1px solid white;
+    border: 1px solid #dc3545;
+    transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;
 }
 
 

--- a/jazzmin/templates/jazzmin/includes/carousel.html
+++ b/jazzmin/templates/jazzmin/includes/carousel.html
@@ -26,12 +26,12 @@
     </ol>
     <div class="carousel-inner">
         {% for fieldset in adminform %}
-            <div class="carousel-item {% if forloop.first %}active{% endif %}" data-carouselId="{{ forloop.counter0 }}" data-label="{{ fieldset.name|default:general_tab|title }}" data-target="#{{ fieldset.name|default:general_tab|unicode_slugify }}-tab">
+            <div class="carousel-item {% if forloop.first %}active{% endif %}" data-carouselId="{{ forloop.counter0 }}" data-label="{{ fieldset.name|default:general_tab|capfirst }}" data-target="#{{ fieldset.name|default:general_tab|unicode_slugify }}-tab">
                 {% include "admin/includes/fieldset.html" with card=adminform|has_fieldsets %}
             </div>
         {% endfor %}
         {% for inline_admin_formset in inline_admin_formsets %}
-            <div class="carousel-item" data-label="{{ inline_admin_formset.opts.verbose_name_plural|title }}" data-target="#{{ inline_admin_formset.opts.verbose_name|unicode_slugify }}-tab">
+            <div class="carousel-item" data-label="{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}" data-target="#{{ inline_admin_formset.opts.verbose_name|unicode_slugify }}-tab">
                 {% include inline_admin_formset.opts.template %}
             </div>
         {% endfor %}

--- a/jazzmin/templates/jazzmin/includes/carousel.html
+++ b/jazzmin/templates/jazzmin/includes/carousel.html
@@ -1,4 +1,5 @@
-{% load jazzmin %}
+{% load i18n jazzmin %}
+{% trans "General" as general_tab %}
 
 <div id="jazzy-carousel" class="carousel slide" data-ride="false" data-wrap="false" data-keyboard="true" data-interval="false">
     <div class="row">
@@ -7,7 +8,7 @@
         </div>
         <div class="col-sm-8 text-center">
             <p class="carousel-fieldset-label">
-                {{ adminform.fieldsets.0.0|default:"General" }}
+                {{ adminform.fieldsets.0.0|default:general_tab }}
             </p>
         </div>
         <div class="col-sm-2">
@@ -25,7 +26,7 @@
     </ol>
     <div class="carousel-inner">
         {% for fieldset in adminform %}
-            <div class="carousel-item {% if forloop.first %}active{% endif %}" data-carouselId="{{ forloop.counter0 }}" data-label="{{ fieldset.name|default:"General"|title }}" data-target="#{{ fieldset.name|default:"General"|unicode_slugify }}-tab">
+            <div class="carousel-item {% if forloop.first %}active{% endif %}" data-carouselId="{{ forloop.counter0 }}" data-label="{{ fieldset.name|default:general_tab|title }}" data-target="#{{ fieldset.name|default:general_tab|unicode_slugify }}-tab">
                 {% include "admin/includes/fieldset.html" with card=adminform|has_fieldsets %}
             </div>
         {% endfor %}

--- a/jazzmin/templates/jazzmin/includes/collapsible.html
+++ b/jazzmin/templates/jazzmin/includes/collapsible.html
@@ -1,14 +1,15 @@
-{% load jazzmin %}
+{% load i18n jazzmin %}
+{% trans "General" as general_tab %}
 
 <div id="jazzy-collapsible">
     {% for fieldset in adminform %}
         <div class="card card-default">
-            <div class="card-header collapsible-header" data-toggle="collapse" data-parent="#jazzy-collapsible" data-target="#{{ fieldset.name|default:"General"|unicode_slugify }}-tab">
+            <div class="card-header collapsible-header" data-toggle="collapse" data-parent="#jazzy-collapsible" data-target="#{{ fieldset.name|default:general_tab|unicode_slugify }}-tab">
                 <h4 class="card-title">
-                    {{ fieldset.name|default:"General" }}
+                    {{ fieldset.name|default:general_tab }}
                 </h4>
             </div>
-            <div id="{{ fieldset.name|default:"General"|unicode_slugify }}-tab" class="panel-collapse in {% if forloop.first %}show{% else %}collapse{% endif %}">
+            <div id="{{ fieldset.name|default:general_tab|unicode_slugify }}-tab" class="panel-collapse in {% if forloop.first %}show{% else %}collapse{% endif %}">
                 <div class="card-body">
                     {% include "admin/includes/fieldset.html" with card=False %}
                 </div>

--- a/jazzmin/templates/jazzmin/includes/collapsible.html
+++ b/jazzmin/templates/jazzmin/includes/collapsible.html
@@ -21,7 +21,7 @@
         <div class="card card-default">
             <div class="card-header collapsible-header" data-toggle="collapse" data-parent="#jazzy-collapsible" data-target="#{{ inline_admin_formset.opts.verbose_name|unicode_slugify }}-tab">
                 <h4 class="card-title">
-                    {{ inline_admin_formset.opts.verbose_name_plural|title }}
+                    {{ inline_admin_formset.opts.verbose_name_plural|capfirst }}
                 </h4>
             </div>
             <div id="{{ inline_admin_formset.opts.verbose_name|unicode_slugify }}-tab" class="panel-collapse in collapse">

--- a/jazzmin/templates/jazzmin/includes/horizontal_tabs.html
+++ b/jazzmin/templates/jazzmin/includes/horizontal_tabs.html
@@ -12,7 +12,7 @@
     {% for inline_admin_formset in inline_admin_formsets %}
         <li class="nav-item">
             <a class="nav-link" data-toggle="pill" role="tab" aria-controls="{{ inline_admin_formset.opts.verbose_name_plural|unicode_slugify }}-tab" aria-selected="false" href="#{{ inline_admin_formset.opts.verbose_name_plural|unicode_slugify }}-tab">
-                {{ inline_admin_formset.opts.verbose_name_plural|title }}
+                {{ inline_admin_formset.opts.verbose_name_plural|capfirst }}
             </a>
         </li>
     {% endfor %}

--- a/jazzmin/templates/jazzmin/includes/horizontal_tabs.html
+++ b/jazzmin/templates/jazzmin/includes/horizontal_tabs.html
@@ -1,10 +1,11 @@
-{% load jazzmin %}
+{% load i18n jazzmin %}
+{% trans "General" as general_tab %}
 
 <ul class="nav nav-tabs" role="tablist" id="jazzy-tabs">
     {% for fieldset in adminform %}
         <li class="nav-item">
-            <a class="nav-link{% if forloop.first %} active{% endif %}" data-toggle="pill" role="tab" aria-controls="{{ fieldset.name|default:"General"|unicode_slugify }}-tab" aria-selected="{% if forloop.first %}true{% else %}false{% endif %}" href="#{{ fieldset.name|default:"General"|unicode_slugify }}-tab">
-                {{ fieldset.name|default:"General" }}
+            <a class="nav-link{% if forloop.first %} active{% endif %}" data-toggle="pill" role="tab" aria-controls="{{ fieldset.name|default:general_tab|unicode_slugify }}-tab" aria-selected="{% if forloop.first %}true{% else %}false{% endif %}" href="#{{ fieldset.name|default:general_tab|unicode_slugify }}-tab">
+                {{ fieldset.name|default:general_tab }}
             </a>
         </li>
     {% endfor %}
@@ -19,7 +20,7 @@
 
 <div class="tab-content">
     {% for fieldset in adminform %}
-        <div id="{{ fieldset.name|default:"General"|unicode_slugify }}-tab" class="tab-pane fade{% if forloop.first %} active show{% endif %}" role="tabpanel" aria-labelledby="{{ fieldset.name|default:"General"|unicode_slugify }}-tab">
+        <div id="{{ fieldset.name|default:general_tab|unicode_slugify }}-tab" class="tab-pane fade{% if forloop.first %} active show{% endif %}" role="tabpanel" aria-labelledby="{{ fieldset.name|default:general_tab|unicode_slugify }}-tab">
             {% include "admin/includes/fieldset.html" with card=True %}
         </div>
     {% endfor %}

--- a/jazzmin/templates/jazzmin/includes/single.html
+++ b/jazzmin/templates/jazzmin/includes/single.html
@@ -8,14 +8,14 @@
     {% if adminform|has_fieldsets %}
         <div class="card">
             <div class="card-header">
-                {{ inline_admin_formset.opts.verbose_name_plural|title }}
+                {{ inline_admin_formset.opts.verbose_name_plural|capfirst }}
             </div>
             <div class="card-body">
                 {% include inline_admin_formset.opts.template %}
             </div>
         </div>
     {% else %}
-        <h6><strong>{{ inline_admin_formset.opts.verbose_name_plural|title }}</strong></h6>
+        <h6><strong>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</strong></h6>
         {% include inline_admin_formset.opts.template %}
     {% endif %}
 {% endfor %}

--- a/jazzmin/templates/jazzmin/includes/vertical_tabs.html
+++ b/jazzmin/templates/jazzmin/includes/vertical_tabs.html
@@ -1,11 +1,12 @@
-{% load jazzmin %}
+{% load i18n jazzmin %}
+{% trans "General" as general_tab %}
 
 <div class="row" id="jazzy-tabs">
     <div class="col-5 col-sm-3">
         <div class="nav flex-column nav-tabs h-100" role="tablist" aria-orientation="vertical">
             {% for fieldset in adminform %}
-                <a class="nav-link {% if forloop.first %}active{% endif %}" data-toggle="pill" href="#{{ fieldset.name|default:"General"|unicode_slugify }}-tab" role="tab" aria-controls="{{ fieldset.name|default:"General"|unicode_slugify }}-tab" aria-selected="{% if forloop.first %}true{% else %}false{% endif %}">
-                    {{ fieldset.name|default:"General" }}
+                <a class="nav-link {% if forloop.first %}active{% endif %}" data-toggle="pill" href="#{{ fieldset.name|default:general_tab|unicode_slugify }}-tab" role="tab" aria-controls="{{ fieldset.name|default:general_tab|unicode_slugify }}-tab" aria-selected="{% if forloop.first %}true{% else %}false{% endif %}">
+                    {{ fieldset.name|default:general_tab }}
                 </a>
             {% endfor %}
             {% for inline_admin_formset in inline_admin_formsets %}
@@ -18,7 +19,7 @@
     <div class="col-7 col-sm-9">
         <div class="tab-content">
             {% for fieldset in adminform %}
-                <div class="tab-pane fade {% if forloop.first %}show active{% endif %}" id="{{ fieldset.name|default:"General"|unicode_slugify }}-tab" role="tabpanel">
+                <div class="tab-pane fade {% if forloop.first %}show active{% endif %}" id="{{ fieldset.name|default:general_tab|unicode_slugify }}-tab" role="tabpanel">
                     {% include "admin/includes/fieldset.html" with card=True %}
                 </div>
             {% endfor %}

--- a/jazzmin/templates/jazzmin/includes/vertical_tabs.html
+++ b/jazzmin/templates/jazzmin/includes/vertical_tabs.html
@@ -11,7 +11,7 @@
             {% endfor %}
             {% for inline_admin_formset in inline_admin_formsets %}
                 <a class="nav-link" data-toggle="pill" href="#{{ inline_admin_formset.opts.verbose_name|unicode_slugify }}-tab" role="tab" aria-controls="{{ inline_admin_formset.opts.verbose_name|unicode_slugify }}-tab" aria-selected="false">
-                    {{ inline_admin_formset.opts.verbose_name_plural|title }}
+                    {{ inline_admin_formset.opts.verbose_name_plural|capfirst }}
                 </a>
             {% endfor %}
         </div>


### PR DESCRIPTION
- now can translate default tab label (General)
- title table lable to capfirst
- restyle "remove" button in inline model as "delete" button in actions

Before (see bug #179), in russian translate:
![изображение](https://user-images.githubusercontent.com/3132181/95823433-f605b700-0d70-11eb-9332-2f290a7b38fb.png)

After:
![изображение](https://user-images.githubusercontent.com/3132181/95824545-d2dc0700-0d72-11eb-831f-b154adfdfc0f.png)
