### PR TITLE
Define a max width for the login form

### DIFF
--- a/jazzmin/static/jazzmin/css/django.css
+++ b/jazzmin/static/jazzmin/css/django.css
@@ -650,6 +650,7 @@ body.no-sidebar .main-header {
 
 .login-box, .register-box {
     width: auto;
+    max-width: 700px;
 }
 
 


### PR DESCRIPTION
Fixes #198

I found this to be the simplest way. Let me know if there are other things to take into account.

Also, I can't find where `register-box` is being used. Maybe it's left over from before?