### PR TITLE
Allow camel cased django app names. Fixes #203.

### DIFF
--- a/jazzmin/settings.py
+++ b/jazzmin/settings.py
@@ -132,6 +132,17 @@ CHANGEFORM_TEMPLATES = {
 }
 
 
+def get_search_model_string(jazzmin_settings):
+    """
+    Get a search model string for reversing an admin url.
+
+    Ensure the model name is lower cased but remain the app name untouched.
+    """
+
+    app, model_name = jazzmin_settings["search_model"].split(".")
+    return "{app}.{model_name}".format(app=app, model_name=model_name.lower())
+
+
 def get_settings() -> Dict:
     jazzmin_settings = copy.deepcopy(DEFAULT_SETTINGS)
     user_settings = {x: y for x, y in getattr(settings, "JAZZMIN_SETTINGS", {}).items() if y is not None}
@@ -139,7 +150,7 @@ def get_settings() -> Dict:
 
     # Extract search url from search model
     if jazzmin_settings["search_model"]:
-        jazzmin_settings["search_url"] = get_admin_url(jazzmin_settings["search_model"].lower())
+        jazzmin_settings["search_url"] = get_admin_url(get_search_model_string(jazzmin_settings))
         model_meta = get_model_meta(jazzmin_settings["search_model"])
         if model_meta:
             jazzmin_settings["search_name"] = model_meta.verbose_name_plural.title()

--- a/jazzmin/utils.py
+++ b/jazzmin/utils.py
@@ -47,7 +47,8 @@ def get_admin_url(instance: Union[str, ModelBase], admin_site: str = "admin", **
     try:
 
         if type(instance) == str:
-            app_label, model_name = instance.lower().split(".")
+            app_label, model_name = instance.split(".")
+            model_name = model_name.lower()
             url = reverse(
                 "admin:{app_label}_{model_name}_changelist".format(app_label=app_label, model_name=model_name),
                 current_app=admin_site,

--- a/jazzmin/utils.py
+++ b/jazzmin/utils.py
@@ -146,7 +146,17 @@ def get_view_permissions(user: AbstractUser) -> Set[str]:
     """
     Get model names based on a users view/change permissions
     """
-    lower_perms = map(lambda x: x.lower(), user.get_all_permissions())
+    perms = user.get_all_permissions()
+    # the perm codenames should always be lower case
+    lower_perms = []
+    for perm in perms:
+        app, perm_codename = perm.split(".")
+        lower_perms.append(
+            "{app}.{perm_codename}".format(
+                app=app,
+                perm_codename=perm_codename.lower(),
+            )
+        )
     return {x.replace("view_", "") for x in lower_perms if "view" in x or "change" in x}
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from django.db.models.functions import Upper
 from django.urls import reverse
@@ -47,6 +49,9 @@ def test_get_admin_url(admin_user):
     assert get_admin_url(Book) == reverse("admin:books_book_changelist")
     assert get_admin_url(Book, q="test") == reverse("admin:books_book_changelist") + "?q=test"
     assert get_admin_url("books.Book") == reverse("admin:books_book_changelist")
+    with patch("jazzmin.utils.reverse") as mock_reverse:
+        get_admin_url("Books.Book")
+        mock_reverse.assert_called_once_with("admin:Books_book_changelist", current_app="admin")
     assert get_admin_url("cheese:bad_pattern") == "#"
     assert get_admin_url("fake_app.fake_model") == "#"
     assert get_admin_url(1) == "#"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock, Mock
 
 import pytest
 from django.db.models.functions import Upper
@@ -99,6 +99,12 @@ def test_get_model_permissions():
     user = UserFactory(permissions=("books.view_book", "books.view_author"))
 
     assert get_view_permissions(user) == {"books.book", "books.author"}
+
+    # test for camel cased app names
+    user = MagicMock()
+    user.get_all_permissions = Mock(return_value={"BookShelf.view_author", "BookShelf.view_book"})
+
+    assert get_view_permissions(user) == {"BookShelf.book", "BookShelf.author"}
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Model admin URLs for camel cased app names where not resolved correctly. This was solved by removing the use of lower() on the app name.