### PR TITLE
Force test@test.com user to use test password

### DIFF
--- a/tests/test_app/library/books/apps.py
+++ b/tests/test_app/library/books/apps.py
@@ -4,3 +4,6 @@ from django.conf import settings
 
 class BooksConfig(AppConfig):
     name = "{}library.books".format(settings.PREFIX)
+
+    def ready(self):
+        from . import receivers  # NOQA

--- a/tests/test_app/library/books/receivers.py
+++ b/tests/test_app/library/books/receivers.py
@@ -1,0 +1,12 @@
+from django.contrib.auth.models import User
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
+
+
+@receiver(pre_save, sender=User)
+def add_user_levels_actions(sender, instance, **kwargs):
+    """
+    Dont allow our test user to change their password
+    """
+    if instance.username == "test@test.com":
+        instance.set_password("test")


### PR DESCRIPTION
When updating the superuser, force the use of our known password, whilst preserving the ability to view and interact with all parts of the admin 

Fixes #205


