### PR TITLE
Farridav/update tabular inline

### DIFF
--- a/jazzmin/templates/admin/edit_inline/stacked.html
+++ b/jazzmin/templates/admin/edit_inline/stacked.html
@@ -31,8 +31,8 @@
                                 {% endif %}
                                 </span>
                                 {% if inline_admin_form.show_url %}
-                                    <a href="{{ inline_admin_form.absolute_url }}">
-                                        <i class="fas fa-eye fa-sm"> </i> {% trans "View on site" %}
+                                    <a href="{{ inline_admin_form.absolute_url }}" title="{% trans "View on site" %}">
+                                        <i class="fas fa-eye fa-sm"> </i>
                                     </a>
                                 {% endif %}
                             </h3>

--- a/jazzmin/templates/admin/edit_inline/tabular.html
+++ b/jazzmin/templates/admin/edit_inline/tabular.html
@@ -41,11 +41,10 @@
                                             {% endif %}
                                         </a>
                                     {% endif %}
-                                    {{ inline_admin_form.original }}
 
                                     {% if inline_admin_form.show_url %}
-                                        <a href="{{ inline_admin_form.absolute_url }}">
-                                            <i class="fas fa-eye fa-sm"> </i> {% trans "View on site" %}
+                                        <a href="{{ inline_admin_form.absolute_url }}" title="{% trans "View on site" %}">
+                                            <i class="fas fa-eye fa-sm"> </i>
                                         </a>
                                     {% endif %}
                                 {% endif %}


### PR DESCRIPTION
Dont show objects __str__ representation in tabular inline as it takes up a whole column, and deviates too much from djangos original implementation

See https://github.com/farridav/django-jazzmin/issues/186 for the issue

Fixes #186