### PR TITLE
Replaces "{ }" with escaped braces "{{ }}" fix for json format string error

### DIFF
--- a/jazzmin/templatetags/jazzmin.py
+++ b/jazzmin/templatetags/jazzmin.py
@@ -447,14 +447,6 @@ def action_message_to_list(action: LogEntry) -> List[Dict]:
     return messages if len(messages) else [changed(gettext(action.change_message))]
 
 
-def escape_json_string(message: str) -> str:
-    """
-    Replaces "{ }" with escaped braces "{{ }}"
-     - fix for format string error in `format_html` with json field
-    """
-    return message.replace('{', '{{').replace('}', '}}')
-
-
 @register.filter
 def style_bold_first_word(message: str) -> SafeText:
     """
@@ -469,9 +461,7 @@ def style_bold_first_word(message: str) -> SafeText:
 
     message = " ".join([word for word in message_words])
 
-    message = escape_json_string(message)
-
-    return format_html(message)
+    return mark_safe(message)
 
 
 @register.filter

--- a/jazzmin/templatetags/jazzmin.py
+++ b/jazzmin/templatetags/jazzmin.py
@@ -447,6 +447,14 @@ def action_message_to_list(action: LogEntry) -> List[Dict]:
     return messages if len(messages) else [changed(gettext(action.change_message))]
 
 
+def escape_json_string(message: str) -> str:
+    """
+    Replaces "{ }" with escaped braces "{{ }}"
+     - fix for format string error in `format_html` with json field
+    """
+    return message.replace('{', '{{').replace('}', '}}')
+
+
 @register.filter
 def style_bold_first_word(message: str) -> SafeText:
     """
@@ -460,6 +468,8 @@ def style_bold_first_word(message: str) -> SafeText:
     message_words[0] = "<strong>{}</strong>".format(message_words[0])
 
     message = " ".join([word for word in message_words])
+
+    message = escape_json_string(message)
 
     return format_html(message)
 


### PR DESCRIPTION
A json field with curly braces can cause an error inside the django function 'format_html' with 'key error'. This resolves that.