### PR TITLE
Added typing and test for get_search_model_string.

### DIFF
--- a/jazzmin/settings.py
+++ b/jazzmin/settings.py
@@ -132,7 +132,7 @@ CHANGEFORM_TEMPLATES = {
 }
 
 
-def get_search_model_string(jazzmin_settings):
+def get_search_model_string(jazzmin_settings: Dict) -> str:
     """
     Get a search model string for reversing an admin url.
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,10 @@
+from jazzmin.settings import get_search_model_string
+
+
+def test_get_search_model_string():
+    # model name is always lower case
+    assert get_search_model_string({"search_model": "books.Book"}) == "books.book"
+    assert get_search_model_string({"search_model": "books.book"}) == "books.book"
+    # the app name gets never touched
+    assert get_search_model_string({"search_model": "Books.Book"}) == "Books.book"
+    assert get_search_model_string({"search_model": "BookShelf.book"}) == "BookShelf.book"


### PR DESCRIPTION
As mentioned in PR for #203 and #204 tests and typing should get added for `get_search_model_string`