### PR TITLE
Set `change_lang` template tag properly - jazzmin.py

### DIFF
--- a/jazzmin/templatetags/jazzmin.py
+++ b/jazzmin/templatetags/jazzmin.py
@@ -263,7 +263,7 @@ def change_lang(request: HttpRequest, language_code: str) -> str:
     Change the url to use the given language
     """
     current_language = translation.get_language()
-    return request.get_full_path().replace(current_language, language_code)
+    return request.get_full_path().replace(current_language, language_code, 1)
 
 
 @register.filter


### PR DESCRIPTION
When there are a few occurrences of language code in the URL, the `change_lang` template tag replaces all URLs. However, most likely it should replace only first occurrence(prefix) of the URL. So It causes an issue and consequently, we are getting 404 page. For example, let's imagine the current URL is `/en/admin/content/content/` and I want to switch to `es` language. Then I'm getting `/es/admin/contest/contest/` (3 es) - non-existing URL