### PR TITLE
Fix to ensure that hidden inputs are correctly hidden from admin screens

### DIFF
--- a/jazzmin/static/jazzmin/css/main.css
+++ b/jazzmin/static/jazzmin/css/main.css
@@ -43,6 +43,10 @@ tr.djn-tr>.original {
     padding-left: 20px;
 }
 
+.hidden {
+    display: none;
+}
+
 /* Checkbox selection table header */
 .djn-checkbox-select-all {
     padding-right: 0 !important;


### PR DESCRIPTION
Fixes issue #225 in a possibly naive way by simply adding the `display: none` attribute to the `hidden` class.

There may be a more elegant solution to this problem so please forgive my naivety if that is the case. 