### PR TITLE
Render fieldset name when using "single" template

### DIFF
--- a/jazzmin/templates/admin/includes/fieldset.html
+++ b/jazzmin/templates/admin/includes/fieldset.html
@@ -1,6 +1,7 @@
 {% load jazzmin %}
 {% if card %}
 <div class="card {{ fieldset.classes|cut:"collapse" }}">
+    {% if card_header and fieldset.name %}<div class="card-header">{{ fieldset.name }}</div>{%endif%}
     <div class="p-5{% if fieldset.name %} card-body{% endif %}">
 {% endif %}
 

--- a/jazzmin/templates/jazzmin/includes/single.html
+++ b/jazzmin/templates/jazzmin/includes/single.html
@@ -1,7 +1,7 @@
 {% load jazzmin %}
 
 {% for fieldset in adminform %}
-    {% include "admin/includes/fieldset.html" with card=adminform|has_fieldsets %}
+    {% include "admin/includes/fieldset.html" with card=adminform|has_fieldsets card_header=adminform|has_fieldsets %}
 {% endfor %}
 
 {% for inline_admin_formset in inline_admin_formsets %}


### PR DESCRIPTION
Hi,

Thanks for the lib, it gives a nice look to the admin UI !

I encountered a small issue, fieldset names are not rendered when using single template. As a comparison, they are in vanilla Django, and also with other templates such as horizontal_tabs.

This PR add the name in a card-header when available and requested.

If anything is missing in this PR, please ping me back so I can do what is needed to make this PR mergeable.

Best regards