### PR TITLE
Add in demonstration of custom view

### DIFF
--- a/tests/test_app/library/loans/admin.py
+++ b/tests/test_app/library/loans/admin.py
@@ -1,6 +1,8 @@
 from django.contrib import admin
+from django.urls import path
 
 from .models import BookLoan, Library
+from .views import CustomView
 
 
 class BookLoanInline(admin.StackedInline):
@@ -29,6 +31,13 @@ class BookLoanAdmin(admin.ModelAdmin):
         (None, {"fields": ("book", "imprint", "id")}),
         ("Availability", {"fields": ("status", "due_back", "duration", "borrower")}),
     )
+
+    def get_urls(self):
+        """
+        Add in a custom view to demonstrate =
+        """
+        urls = super().get_urls()
+        return urls + [path("custom_view", CustomView.as_view(), name="custom_view")]
 
     def response_change(self, request, obj):
         ret = super().response_change(request, obj)

--- a/tests/test_app/library/loans/templates/loans/custom.html
+++ b/tests/test_app/library/loans/templates/loans/custom.html
@@ -1,0 +1,30 @@
+{% extends "admin/base.html" %}
+{% block content %}
+
+    <div class="col-12 col-sm-8">
+        <div class="card card-primary card-outline">
+            <div class="card-header">
+                <div class="card-title">
+                    Some title
+                </div>
+            </div>
+            <div class="card-body">
+                Some content
+            </div>
+        </div>
+    </div>
+
+    <div class="col-12 col-sm-4">
+        <div class="card card-secondary card-outline">
+            <div class="card-header">
+                <div class="card-title">
+                    Some title
+                </div>
+            </div>
+            <div class="card-body">
+                Some content
+            </div>
+        </div>
+    </div>
+
+{% endblock %}

--- a/tests/test_app/library/loans/views.py
+++ b/tests/test_app/library/loans/views.py
@@ -1,0 +1,11 @@
+from django.views.generic import TemplateView
+from django.contrib.admin.sites import site
+
+
+class CustomView(TemplateView):
+    template_name = "loans/custom.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx.update(site.each_context(self.request))
+        return ctx

--- a/tests/test_app/library/settings.py
+++ b/tests/test_app/library/settings.py
@@ -189,11 +189,7 @@ JAZZMIN_SETTINGS = {
                 "icon": "fas fa-comments",
                 "permissions": ["loans.view_loan"],
             },
-            {
-                "name": "Custom View",
-                "url": "admin:custom_view",
-                "icon": "fas fa-box-open"
-            },
+            {"name": "Custom View", "url": "admin:custom_view", "icon": "fas fa-box-open"},
         ]
     },
     # Custom icons for side menu apps/models See https://fontawesome.com/icons?d=gallery&m=free

--- a/tests/test_app/library/settings.py
+++ b/tests/test_app/library/settings.py
@@ -188,7 +188,12 @@ JAZZMIN_SETTINGS = {
                 "url": "make_messages",
                 "icon": "fas fa-comments",
                 "permissions": ["loans.view_loan"],
-            }
+            },
+            {
+                "name": "Custom View",
+                "url": "admin:custom_view",
+                "icon": "fas fa-box-open"
+            },
         ]
     },
     # Custom icons for side menu apps/models See https://fontawesome.com/icons?d=gallery&m=free

--- a/tests/test_jazzmin_menus.py
+++ b/tests/test_jazzmin_menus.py
@@ -35,6 +35,7 @@ def test_side_menu(admin_client, settings):
             "/make_messages/",
             "/en/admin/loans/bookloan/",
             "/en/admin/loans/library/",
+            "/en/admin/loans/bookloan/custom_view",
         ],
     }
 
@@ -53,6 +54,7 @@ def test_side_menu(admin_client, settings):
             "/make_messages/",
             "/en/admin/loans/bookloan/",
             "/en/admin/loans/library/",
+            "/en/admin/loans/bookloan/custom_view",
         ],
         "Administration": ["/en/admin/admin/logentry/"],
     }


### PR DESCRIPTION
Fixes: https://github.com/farridav/django-jazzmin/issues/235

@jamesreinhold perhaps this will help ? its a demonstration of how one might add a custom admin view into jazzmin..

The important thing here is the use of `site.each_context(self.request)` when rendering the view, as that contains vital information that we use to render out the menus, (if you use a custom admin site, then import that instead of the default one). I hope to get this written up in our docs soon.

- Adds a custom view
- Adds that view to the admin urls for a given app
- Uses a custom template, end some sample markup to demonstrate
- Adds the new view into the menu under a given app

All of this said, for your use case, you could also have just added a template file at  `support/templates/admin/support/messages/change_form.html` with similar HTML to that of custom.html