### PR TITLE
Revert select2 width to auto

### DIFF
--- a/jazzmin/static/jazzmin/js/change_form.js
+++ b/jazzmin/static/jazzmin/js/change_form.js
@@ -109,7 +109,7 @@
         // Apply select2 to any select boxes that don't yet have it
         // and are not part of the django's empty-form inline
         const noSelect2 = '.empty-form select, .select2-hidden-accessible, .selectfilter, .selector-available select, .selector-chosen select';
-        $('select').not(noSelect2).select2({ width: 'element' });
+        $('select').not(noSelect2).select2({ width: 'auto' });
     }
 
     $(document).ready(function () {

--- a/jazzmin/static/jazzmin/js/change_list.js
+++ b/jazzmin/static/jazzmin/js/change_list.js
@@ -25,14 +25,14 @@
         // Make search filters select2 and ensure they work for filtering
         const $ele = $('.search-filter');
         $ele.search_filters();
-        $ele.select2({  width: 'element' });
+        $ele.select2({  width: 'auto' });
 
         // Use select2 for mptt dropdowns
         const $mptt = $('.search-filter-mptt');
         if ($mptt.length) {
             $mptt.search_filters();
             $mptt.select2({
-                width: '100%',
+                width: 'auto',
                 templateResult: function (data) {
                     // https://stackoverflow.com/questions/30820215/selectable-optgroups-in-select2#30948247
                     // rewrite templateresult for build tree hierarchy

--- a/jazzmin/templates/jazzmin/widgets/select.html
+++ b/jazzmin/templates/jazzmin/widgets/select.html
@@ -3,4 +3,4 @@
     {% include option.template_name with widget=option %}{% endfor %}{% if group_name %}
 </optgroup>{% endif %}{% endfor %}
 </select>
-<script>django.jQuery('#id_{{ widget.name }}').select2({ width: '100%' })</script>
+<script>django.jQuery('#id_{{ widget.name }}').select2({ width: 'auto' })</script>


### PR DESCRIPTION
Using `element` as the width for select2 elements appears to have adverse effects for some people (See https://github.com/farridav/django-jazzmin/issues/242)

The width has been changed from `element` to `auto` (the CSS property value) See https://select2.org/appearance#container-width for all options.

test with `pip install "git+https://github.com/farridav/django-jazzmin.git@hotfix/select2_element_auto"`

It appears to renders as expected in the demo app

![image](https://user-images.githubusercontent.com/2966253/104093020-a9eae580-527f-11eb-9298-b016ce9bb424.png)

@jonasjahns / @linhnvhicts / @SVDouble let me know if this resolves your issue or introduces any new ones, everything i have checked thus far seems ok.

Fixes: https://github.com/farridav/django-jazzmin/issues/242