### PR TITLE
Show error when logged in but no admin access

### DIFF
--- a/jazzmin/templates/admin/login.html
+++ b/jazzmin/templates/admin/login.html
@@ -58,6 +58,18 @@
             <p class="login-box-msg">{{ jazzmin_settings.welcome_sign }}</p>
             <form action="{{ app_path }}" method="post">
                 {% csrf_token %}
+                {% if user.is_authenticated %}
+                    <p class="errornote">
+                        <div class="callout callout-danger">
+                            <p>
+                                {% blocktrans trimmed %}
+                                    You are authenticated as {{ username }}, but are not authorized to
+                                    access this page. Would you like to login to a different account?
+                                {% endblocktrans %}
+                            </p>
+                        </div>
+                    </p>
+                {% endif %}
                 {% if form.errors %}
 
                     {% if form.username.errors %}


### PR DESCRIPTION
Shows when a user is logged in, but has no staff access, replicating behaviour from django, something we have missed out as we implement our own login page

Fixes: https://github.com/farridav/django-jazzmin/issues/247

![image](https://user-images.githubusercontent.com/2966253/104822577-71c54300-583b-11eb-8fe7-9959e481480c.png)
