### PR TITLE
Select2, use element again, bu with min width

### DIFF
--- a/jazzmin/static/jazzmin/css/main.css
+++ b/jazzmin/static/jazzmin/css/main.css
@@ -109,6 +109,10 @@ table.dataTable thead .sorting_desc_disabled::after {
     content: "\2193";
 }
 
+.select2-container {
+    min-width: 200px;
+}
+
 .select2-container .select2-selection--single {
     min-height: 40px;
     padding-top: 5px;

--- a/jazzmin/static/jazzmin/js/change_form.js
+++ b/jazzmin/static/jazzmin/js/change_form.js
@@ -109,7 +109,7 @@
         // Apply select2 to any select boxes that don't yet have it
         // and are not part of the django's empty-form inline
         const noSelect2 = '.empty-form select, .select2-hidden-accessible, .selectfilter, .selector-available select, .selector-chosen select';
-        $('select').not(noSelect2).select2({ width: 'auto' });
+        $('select').not(noSelect2).select2({ width: 'element' });
     }
 
     $(document).ready(function () {

--- a/jazzmin/static/jazzmin/js/change_list.js
+++ b/jazzmin/static/jazzmin/js/change_list.js
@@ -25,14 +25,14 @@
         // Make search filters select2 and ensure they work for filtering
         const $ele = $('.search-filter');
         $ele.search_filters();
-        $ele.select2({  width: 'auto' });
+        $ele.select2({  width: 'element' });
 
         // Use select2 for mptt dropdowns
         const $mptt = $('.search-filter-mptt');
         if ($mptt.length) {
             $mptt.search_filters();
             $mptt.select2({
-                width: 'auto',
+                width: 'element',
                 templateResult: function (data) {
                     // https://stackoverflow.com/questions/30820215/selectable-optgroups-in-select2#30948247
                     // rewrite templateresult for build tree hierarchy

--- a/jazzmin/templates/jazzmin/widgets/select.html
+++ b/jazzmin/templates/jazzmin/widgets/select.html
@@ -3,4 +3,4 @@
     {% include option.template_name with widget=option %}{% endfor %}{% if group_name %}
 </optgroup>{% endif %}{% endfor %}
 </select>
-<script>django.jQuery('#id_{{ widget.name }}').select2({ width: 'auto' })</script>
+<script>django.jQuery('#id_{{ widget.name }}').select2({ width: 'element' })</script>

--- a/tests/test_app/library/settings.py
+++ b/tests/test_app/library/settings.py
@@ -78,18 +78,10 @@ DATABASES = {
 }
 
 AUTH_PASSWORD_VALIDATORS = [
-    {
-        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
-    },
-    {
-        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
-    },
-    {
-        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
-    },
-    {
-        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
-    },
+    {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},
+    {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},
+    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
+    {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
 ]
 
 LANGUAGE_CODE = "en"
@@ -144,11 +136,7 @@ JAZZMIN_SETTINGS = {
         # Url that gets reversed (Permissions can be added)
         {"name": "Home", "url": "admin:index", "permissions": ["auth.view_user"]},
         # external url that opens in a new window (Permissions can be added)
-        {
-            "name": "Support",
-            "url": "https://github.com/farridav/django-jazzmin/issues",
-            "new_window": True,
-        },
+        {"name": "Support", "url": "https://github.com/farridav/django-jazzmin/issues", "new_window": True},
         # model admin to link to (Permissions checked against model)
         {"model": "auth.User"},
         # App with dropdown menu to all its models pages (Permissions checked against models)
@@ -160,11 +148,7 @@ JAZZMIN_SETTINGS = {
     #############
     # Additional links to include in the user menu on the top right ('app' url type is not allowed)
     "usermenu_links": [
-        {
-            "name": "Support",
-            "url": "https://github.com/farridav/django-jazzmin/issues",
-            "new_window": True,
-        },
+        {"name": "Support", "url": "https://github.com/farridav/django-jazzmin/issues", "new_window": True},
         {"model": "auth.user"},
     ],
     #############


### PR DESCRIPTION
- Setting a min-width on select2 containers
- using `element` for select2 container width as it appears to yield the best results (https://select2.org/appearance#container-width)

Fixes: https://github.com/farridav/django-jazzmin/issues/245

Hopefully doesnt re-open https://github.com/farridav/django-jazzmin/issues/242 (the min width should help)