### PR TITLE
Default site title and header from current admin site

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,10 +6,10 @@ full example, with some of the more complex items explained below that.
 ## Full example
 ```python
 JAZZMIN_SETTINGS = {
-    # title of the window
+    # title of the window (Will default to current_admin_site.site_title if absent or None)
     "site_title": "Library Admin",
 
-    # Title on the brand, and the login screen (19 chars max)
+    # Title on the brand, and login screen (19 chars max) (defaults to current_admin_site.site_header if absent or None)
     "site_header": "Library",
 
     # square logo to use for your site, must be present in static files, used for favicon and brand on top left

--- a/jazzmin/settings.py
+++ b/jazzmin/settings.py
@@ -3,7 +3,6 @@ import logging
 from typing import Dict
 
 from django.conf import settings
-from django.contrib.admin import AdminSite
 from django.templatetags.static import static
 
 from .utils import get_admin_url, get_model_meta
@@ -11,10 +10,10 @@ from .utils import get_admin_url, get_model_meta
 logger = logging.getLogger(__name__)
 
 DEFAULT_SETTINGS = {
-    # title of the window
-    "site_title": AdminSite.site_title,
-    # Title on the brand, and the login screen (19 chars max)
-    "site_header": AdminSite.site_header,
+    # title of the window (Will default to current_admin_site.site_title)
+    "site_title": None,
+    # Title on the brand, and the login screen (19 chars max) (will default to current_admin_site.site_header)
+    "site_header": None,
     # Relative path to logo for your site, used for favicon and brand on top left (must be present in static files)
     "site_logo": "vendor/adminlte/img/AdminLTELogo.png",
     # Welcome text on the login screen

--- a/jazzmin/templates/admin/base.html
+++ b/jazzmin/templates/admin/base.html
@@ -1,7 +1,7 @@
 {% load i18n static jazzmin admin_urls %}
 {% get_current_language as LANGUAGE_CODE %}
 {% get_current_language_bidi as LANGUAGE_BIDI %}
-{% get_jazzmin_settings as jazzmin_settings %}
+{% get_jazzmin_settings request as jazzmin_settings %}
 {% get_jazzmin_ui_tweaks as jazzmin_ui %}
 
 <!DOCTYPE html>

--- a/jazzmin/templates/admin/change_form.html
+++ b/jazzmin/templates/admin/change_form.html
@@ -1,6 +1,6 @@
 {% extends "admin/base_site.html" %}
 {% load i18n admin_urls static admin_modify jazzmin %}
-{% get_jazzmin_settings as jazzmin_settings %}
+{% get_jazzmin_settings request as jazzmin_settings %}
 
 {% block extrastyle %}
     {{ block.super }}

--- a/jazzmin/templates/admin/login.html
+++ b/jazzmin/templates/admin/login.html
@@ -1,7 +1,7 @@
 {% load i18n static jazzmin admin_urls %}
 {% get_current_language as LANGUAGE_CODE %}
 {% get_current_language_bidi as LANGUAGE_BIDI %}
-{% get_jazzmin_settings as jazzmin_settings %}
+{% get_jazzmin_settings request as jazzmin_settings %}
 {% get_jazzmin_ui_tweaks as jazzmin_ui %}
 
 <!DOCTYPE html>

--- a/jazzmin/templates/registration/logged_out.html
+++ b/jazzmin/templates/registration/logged_out.html
@@ -1,7 +1,7 @@
 {% load i18n static jazzmin admin_urls %}
 {% get_current_language as LANGUAGE_CODE %}
 {% get_current_language_bidi as LANGUAGE_BIDI %}
-{% get_jazzmin_settings as jazzmin_settings %}
+{% get_jazzmin_settings request as jazzmin_settings %}
 {% get_jazzmin_ui_tweaks as jazzmin_ui %}
 
 <!DOCTYPE html>

--- a/jazzmin/templatetags/jazzmin.py
+++ b/jazzmin/templatetags/jazzmin.py
@@ -9,10 +9,12 @@ from django.conf import settings
 from django.contrib.admin import ListFilter
 from django.contrib.admin.helpers import AdminForm
 from django.contrib.admin.models import LogEntry
+from django.contrib.admin.sites import all_sites
 from django.contrib.admin.views.main import PAGE_VAR, ChangeList
 from django.contrib.auth import get_user_model
 from django.contrib.auth.context_processors import PermWrapper
 from django.contrib.auth.models import AbstractUser
+from django.core.handlers.wsgi import WSGIRequest
 from django.db.models.base import ModelBase
 from django.http import HttpRequest
 from django.template import Library, Context
@@ -125,11 +127,20 @@ def get_user_menu(user: AbstractUser, admin_site: str = "admin") -> List[Dict]:
 
 
 @register.simple_tag
-def get_jazzmin_settings() -> Dict:
+def get_jazzmin_settings(request: WSGIRequest) -> Dict:
     """
-    Return Jazzmin settings
+    Get Jazzmin settings, update any defaults from the request, and return
     """
-    return get_settings()
+    settings = get_settings()
+    admin_site = {x.name: x for x in all_sites}.get(request.current_app)
+    if admin_site:
+        if not settings["site_title"]:
+            settings["site_title"] = admin_site.site_title
+
+        if not settings["site_header"]:
+            settings["site_header"] = admin_site.site_header
+
+    return settings
 
 
 @register.simple_tag

--- a/tests/test_app/library/settings.py
+++ b/tests/test_app/library/settings.py
@@ -114,9 +114,9 @@ if not DEBUG and not TEST:
 # Third party settings #
 ########################
 JAZZMIN_SETTINGS = {
-    # title of the window
+    # title of the window (Will default to current_admin_site.site_title if absent or None)
     "site_title": "Library Admin",
-    # Title on the brand, and the login screen (19 chars max)
+    # Title on the brand, and login screen (19 chars max) (defaults to current_admin_site.site_header if absent or None)
     "site_header": "Library",
     # square logo to use for your site, must be present in static files, used for favicon and brand on top left
     "site_logo": "books/img/logo.png",


### PR DESCRIPTION
Use the "current" admin site for site title and header defaults, this has to be determined from the request

Fixes https://github.com/farridav/django-jazzmin/issues/249



@olof 

Let me know if this resolves your issue, i was able to confirm it working using your commit
