### PR TITLE
Day is sometimes max 28 (if Feb).

### DIFF
--- a/tests/test_app/library/factories.py
+++ b/tests/test_app/library/factories.py
@@ -82,7 +82,9 @@ class AuthorFactory(DjangoModelFactory):
     first_name = factory.Faker("first_name")
     last_name = factory.Faker("last_name")
     date_of_birth = FuzzyDate(date(1950, 1, 1), NOW.date() - timedelta(days=365))
-    date_of_death = factory.LazyAttribute(lambda x: x.date_of_birth.replace(year=NOW.year))
+    date_of_death = factory.LazyAttribute(
+        lambda x: x.date_of_birth.replace(year=NOW.year, day=min(28, x.date_of_birth.day))
+    )
 
     class Meta:
         model = Author


### PR DESCRIPTION
There is some logic in the CI that breaks when it has selected 29 Feb in a leap year. 

Here, I just change the day to always max 28. 