### PR TITLE
Scroll for fixed sidebar

### DIFF
--- a/jazzmin/static/jazzmin/css/main.css
+++ b/jazzmin/static/jazzmin/css/main.css
@@ -831,20 +831,23 @@ body.jazzmin-login-page {
 }
 
 /* sidebar scrolling */
-#jazzy-sidebar {
+.layout-fixed #jazzy-sidebar {
+    top: 0;
+    bottom: 0;
     /* Enable y scroll */
     overflow-y: scroll;
     /* May inherit scroll, so we need to explicitly hide */
     overflow-x: hidden;
-    /* support for position absolute/fixed */
-    top: 0;
-    bottom: 0;
+}
+/* calculate height to fit content, we don't to enable scrolling if the content fits */
+.layout-fixed #jazzy-sidebar .sidebar {
+    height: auto !important;
 }
 /* Hide scrollbar */
-#jazzy-sidebar {
+.layout-fixed #jazzy-sidebar {
     scrollbar-width: none;
 }
-#jazzy-sidebar::-webkit-scrollbar {
+.layout-fixed #jazzy-sidebar::-webkit-scrollbar {
     width: 0;
 }
 /* nav-item will overflow container in width if scrollbar is visible */

--- a/jazzmin/static/jazzmin/css/main.css
+++ b/jazzmin/static/jazzmin/css/main.css
@@ -829,3 +829,25 @@ body.jazzmin-login-page {
 .callout {
     color: black;
 }
+
+/* sidebar scrolling */
+#jazzy-sidebar {
+    /* Enable y scroll */
+    overflow-y: scroll;
+    /* May inherit scroll, so we need to explicitly hide */
+    overflow-x: hidden;
+    /* support for position absolute/fixed */
+    top: 0;
+    bottom: 0;
+}
+/* Hide scrollbar */
+#jazzy-sidebar {
+    scrollbar-width: none;
+}
+#jazzy-sidebar::-webkit-scrollbar {
+    width: 0;
+}
+/* nav-item will overflow container in width if scrollbar is visible */
+#jazzy-sidebar .nav-sidebar > .nav-item {
+    width: 100%;
+}


### PR DESCRIPTION
Right now **fixed** sidebar does not support scrolling and if you have a lot of apps it becomes a trouble

1. Can't access apps in the end
![image](https://user-images.githubusercontent.com/18076967/112734207-5a01ed80-8f55-11eb-823a-ce0566380420.png)
2. The default scroll may seem ugly + it makes `.nav-item` overflow its container which breaks paddings or just cuts of the edge of **rounded** button (already fixed with `width: 100%`)
![image](https://user-images.githubusercontent.com/18076967/112734337-2d9aa100-8f56-11eb-94bf-846142145ab2.png)
![image](https://user-images.githubusercontent.com/18076967/112734423-aac61600-8f56-11eb-9c35-f56b02f9afe7.png)
3. Making everything even worse, fixed sidebar makes `overflow-x` inherit `scroll`
![image](https://user-images.githubusercontent.com/18076967/112734406-941fbf00-8f56-11eb-81aa-1f6ef2837f52.png)

----------------

**Solution**

This PR proposes elegant and css-way of fixing this issue making fixed sidebar scrollable while hiding the scrollbar. Also `.nav-item` won't overflow even if the browser will render the scrollbar 
![image](https://user-images.githubusercontent.com/18076967/112734492-24f69a80-8f57-11eb-93b3-4ee5a3741dc2.png)

