### PR TITLE
Remove permissions check for History button to match Django

### DIFF
--- a/jazzmin/templates/admin/change_form_object_tools.html
+++ b/jazzmin/templates/admin/change_form_object_tools.html
@@ -2,10 +2,8 @@
 {% get_jazzmin_ui_tweaks as jazzmin_ui %}
 
 {% block object-tools-items %}
-    {% if perms.administration.can_change_logs or perms.administration.can_view_logs %}
-        {% url opts|admin_urlname:'history' original.pk|admin_urlquote as history_url %}
-        <a class="btn btn-block {{ jazzmin_ui.button_classes.secondary }} btn-sm" href="{% add_preserved_filters history_url %}">{% trans 'History' %}</a>
-    {% endif %}
+    {% url opts|admin_urlname:'history' original.pk|admin_urlquote as history_url %}
+    <a class="btn btn-block {{ jazzmin_ui.button_classes.secondary }} btn-sm" href="{% add_preserved_filters history_url %}">{% trans 'History' %}</a>
     {% if has_absolute_url %}
         <a href="{{ absolute_url }}" class="btn btn-block {{ jazzmin_ui.button_classes.secondary }} btn-sm">{% trans "View on site" %}</a>
     {% endif %}

--- a/jazzmin/templates/admin/solo/change_form.html
+++ b/jazzmin/templates/admin/solo/change_form.html
@@ -11,9 +11,7 @@
 {% endblock %}
 
 {% block object-tools-items %}
-    {% if perms.administration.can_change_logs or perms.administration.can_view_logs %}
-        <a class="btn btn-block {{ jazzmin_ui.button_classes.secondary }} btn-sm" href="{% url opts|admin_urlname:'history' %}">{% trans 'History' %}</a>
-    {% endif %}
+    <a class="btn btn-block {{ jazzmin_ui.button_classes.secondary }} btn-sm" href="{% url opts|admin_urlname:'history' %}">{% trans 'History' %}</a>
     {% if has_absolute_url %}
         <a href="{% url 'admin:view_on_site' content_type_id original.pk %}" class="btn btn-block {{ jazzmin_ui.button_classes.secondary }} btn-sm">{% trans "View on site" %}</a>
     {% endif %}


### PR DESCRIPTION
Resolves https://github.com/farridav/django-jazzmin/issues/283

I can't see any permissions required for the `History` section in Django admin, and with `django-jazzmin`, navigating to `/history` works. This PR removes the conditional button rendering to (hopefully) match Django 🙂