### PR TITLE
add event listener resize for GeoDjango Pointfield map

### DIFF
--- a/jazzmin/static/jazzmin/js/main.js
+++ b/jazzmin/static/jazzmin/js/main.js
@@ -41,6 +41,15 @@
         }
     }
 
+    function callResizeOnTabSwitch() {
+        /*
+        used to reinitialize the map on a GeoDjango Pointfield
+        */
+        $('a[data-toggle="pill"]').on('shown.bs.tab', function (event) {
+        window.dispatchEvent(new Event('resize'));
+        });
+    }
+
     $(document).ready(function () {
         // Set active status on links
         setActiveLinks()
@@ -55,6 +64,9 @@
         if ($changeListTable.length && !$changeListTable.hasClass('table table-striped')) {
             $changeListTable.addClass('table table-striped');
         }
+
+        // call resize in change view after tab switch
+        callResizeOnTabSwitch();
 
     });
 


### PR DESCRIPTION
We have a project where we use the PointField from GeoDjango. If the map is on the second tab it's size is 0px.
To fix this we call a document resize and the map gets also resized.

Maybe the same issue can happen with some other fields.

fix #265 