### PR TITLE
Fix paginator being passed an elipsis

### DIFF
--- a/jazzmin/templatetags/jazzmin.py
+++ b/jazzmin/templatetags/jazzmin.py
@@ -183,7 +183,7 @@ def jazzmin_paginator_number(cl: ChangeList, i: int) -> SafeText:
     """
     Generate an individual page index link in a paginated list.
     """
-    if i == ".":
+    if i in (".", "…"):
         html_str = """
             <li class="page-item">
             <a class="page-link" href="javascript:void(0);" data-dt-idx="3" tabindex="0">… </a>


### PR DESCRIPTION
Fixes https://github.com/farridav/django-jazzmin/issues/281

It seems on certain versions of django, an elipses is passed into the paginator as oppossed to a period, this deals with that eventuality 