### PR TITLE
Add correct classes to django actions html

### DIFF
--- a/jazzmin/templates/admin/actions.html
+++ b/jazzmin/templates/admin/actions.html
@@ -15,8 +15,8 @@
             {% if actions_selection_counter %}
                 <span class="action-counter" data-actions-icnt="{{ cl.result_list|length }}">{{ selection_note }}</span>
                 {% if cl.result_count != cl.result_list|length %}
-                    <span class="all" style="display: none;">{{ selection_note_all }}</span>
-                    <span class="question" style="display: none;">
+                    <span class="all hidden">{{ selection_note_all }}</span>
+                    <span class="question hidden">
                         <a href="#" title="{% trans "Click here to select the objects across all pages" %}">
                             {% blocktrans with cl.result_count as total_count %}Select all {{ total_count }} {{ module_name }}{% endblocktrans %}
                         </a>


### PR DESCRIPTION
I noticed that the 'select all x models' functionality wasn't working (I'm running Django 3.2). From digging into it, it looks like it's related to the use of the `hidden` class over the inline styles which was changed in Django 3.2 as per the commit here: https://github.com/django/django/commit/30e59705fc3e3e9e8370b965af794ad6173bf92b.

As I'm writing this, I think the change that I've suggested here, however, would mean this functionality would not work correctly for versions of django prior to 3.2 - I'll have a think about whether there's a better solution but please let me know your thoughts if you have time.