### PR TITLE
Fixed checkIfInIframe and initialized related modal for formsets

### DIFF
--- a/jazzmin/static/jazzmin/js/related-modal.js
+++ b/jazzmin/static/jazzmin/js/related-modal.js
@@ -67,7 +67,7 @@
 
         if (checkIfInIframe) {
             // select second to last iframe in the main parent document
-            const secondLastIframe = $('iframe', win.parent.document).eq(-2);
+            const secondLastIframe = $('iframe.related-iframe', win.parent.document).eq(-2);
             let documentContext;
 
             // if second to last iframe exists get its contents
@@ -182,5 +182,7 @@
     $(document).ready(function(){
         init()
     });
+
+    django.jQuery(document).on('formset:added', init);
 
 })(jQuery);


### PR DESCRIPTION
1. This issue is similar to #313, we should not get elements by tag name. It's better to use class name instead :)
2. Modal was not being initialized in inline formsets with `raw_id_fields` (screenshot). In this case the content of modal was opened in new window.
![inline_formset_raw_id_fields](https://user-images.githubusercontent.com/19933234/121698914-c4471a80-cace-11eb-8911-38c787d4df9c.png)
