### PR TITLE
split brand from header

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,8 +9,11 @@ JAZZMIN_SETTINGS = {
     # title of the window (Will default to current_admin_site.site_title if absent or None)
     "site_title": "Library Admin",
 
-    # Title on the brand, and login screen (19 chars max) (defaults to current_admin_site.site_header if absent or None)
+    # Title on the login screen (19 chars max) (defaults to current_admin_site.site_header if absent or None)
     "site_header": "Library",
+
+    # Title on the brand (19 chars max) (defaults to current_admin_site.site_header if absent or None)
+    "site_brand": "Library",
 
     # Logo to use for your site, must be present in static files, used for brand on top left
     "site_logo": "books/img/logo.png",

--- a/jazzmin/settings.py
+++ b/jazzmin/settings.py
@@ -12,8 +12,10 @@ logger = logging.getLogger(__name__)
 DEFAULT_SETTINGS: Dict[str, Any] = {
     # title of the window (Will default to current_admin_site.site_title)
     "site_title": None,
-    # Title on the brand, and the login screen (19 chars max) (will default to current_admin_site.site_header)
+    # Title on the login screen (19 chars max) (will default to current_admin_site.site_header)
     "site_header": None,
+    # Title on the brand (19 chars max) (will default to current_admin_site.site_header)
+    "site_brand": None,
     # Relative path to logo for your site, used for brand on top left (must be present in static files)
     "site_logo": "vendor/adminlte/img/AdminLTELogo.png",
     # CSS classes that are applied to the logo

--- a/jazzmin/templates/admin/base.html
+++ b/jazzmin/templates/admin/base.html
@@ -61,7 +61,7 @@
                 {% else %}
                     <li class="nav-item">
                         <a href="{% url 'admin:index' %}" class="brand-link">
-                            <img src="{% static jazzmin_settings.site_logo %}" alt="{{ jazzmin_settings.site_header }} Logo" class="{{ jazzmin_settings.site_logo_classes }} brand-image elevation-3" style="opacity: .8; margin: 0 0 0 5px;">
+                            <img src="{% static jazzmin_settings.site_logo %}" alt="{{ jazzmin_settings.site_header }} Logo" class="{{ jazzmin_settings.site_logo_classes }} brand-image" style="opacity: .8; margin: 0 0 0 5px;">
                         </a>
                     </li>
                 {% endif %}
@@ -179,7 +179,7 @@
             <aside class="main-sidebar elevation-4 {{ jazzmin_ui.sidebar_classes }}" id="jazzy-sidebar">
                 <a href="{% url 'admin:index' %}" class="brand-link {{ jazzmin_ui.brand_classes }}" id="jazzy-logo">
                     <img src="{% static jazzmin_settings.site_logo %}" alt="{{ jazzmin_settings.site_header }} Logo" class="{{ jazzmin_settings.site_logo_classes }} brand-image elevation-3" style="opacity: .8">
-                    <span class="brand-text font-weight-light">{{ jazzmin_settings.site_header }}</span>
+                    <span class="brand-text font-weight-light">{{ jazzmin_settings.site_brand }}</span>
                 </a>
 
                 <div class="sidebar">

--- a/jazzmin/templatetags/jazzmin.py
+++ b/jazzmin/templatetags/jazzmin.py
@@ -142,6 +142,9 @@ def get_jazzmin_settings(request: WSGIRequest) -> Dict:
         if not settings["site_header"]:
             settings["site_header"] = admin_site.site_header
 
+        if not settings["site_brand"]:
+            settings["site_brand"] = admin_site.site_header
+
     return settings
 
 


### PR DESCRIPTION
remove "elevation-3" to avoid creapy shadowing on logo

split site_header to site_header  and site_brand

site_header is on login_screen
site_brand  is Title on brand

so brand can be reduced to logo only, with empty string, or short name of brand