### PR TITLE
Highlight, and expand active app when on detail view

### DIFF
--- a/jazzmin/static/jazzmin/js/main.js
+++ b/jazzmin/static/jazzmin/js/main.js
@@ -56,7 +56,14 @@
         const $changeListTable = $('#changelist .results table');
         if ($changeListTable.length && !$changeListTable.hasClass('table table-striped')) {
             $changeListTable.addClass('table table-striped');
-        }
+        };
+
+        var a_active = $('a.nav-link.active');
+        var main_li_parent = a_active.closest('li.nav-item.has-treeview');
+        var ul_child = main_li_parent.children('ul');
+
+        ul_child.show();
+        main_li_parent.addClass('menu-is-opening menu-open');
 
     });
 

--- a/jazzmin/static/jazzmin/js/main.js
+++ b/jazzmin/static/jazzmin/js/main.js
@@ -38,8 +38,15 @@
             $link.addClass('active');
         } else if ($parent_link.length) {
             $parent_link.addClass('active');
-        }
-    }
+        };
+
+        const $a_active = $('a.nav-link.active');
+        const $main_li_parent = $a_active.closest('li.nav-item.has-treeview');
+        const $ul_child = $main_li_parent.children('ul');
+
+        $ul_child.show();
+        $main_li_parent.addClass('menu-is-opening menu-open');
+    };
 
 
 
@@ -57,14 +64,6 @@
         if ($changeListTable.length && !$changeListTable.hasClass('table table-striped')) {
             $changeListTable.addClass('table table-striped');
         };
-
-        var a_active = $('a.nav-link.active');
-        var main_li_parent = a_active.closest('li.nav-item.has-treeview');
-        var ul_child = main_li_parent.children('ul');
-
-        ul_child.show();
-        main_li_parent.addClass('menu-is-opening menu-open');
-
     });
 
 })(jQuery);


### PR DESCRIPTION
_Edited:_

When going to the detail view of a model, find the parent app group in the sidemenu, highlight and expand it e.g@

![image](https://user-images.githubusercontent.com/2966253/149664379-38696eb7-fa51-4372-9624-814b2a359cf8.png)

Nothing selected:

![image](https://user-images.githubusercontent.com/2966253/149664399-2231bbc4-9d70-4257-b870-32a0ce51a5e5.png)
