### PR TITLE
show fieldset description

### DIFF
--- a/jazzmin/templates/admin/includes/fieldset.html
+++ b/jazzmin/templates/admin/includes/fieldset.html
@@ -2,6 +2,9 @@
 {% if card %}
 <div class="card {{ fieldset.classes|cut:"collapse" }}">
     {% if card_header and fieldset.name %}<div class="card-header">{{ fieldset.name }}</div>{%endif%}
+    {% if fieldset.description %}
+        <div class="p-2">{{ fieldset.description }}</div>
+    {% endif %}
     <div class="p-5{% if fieldset.name %} card-body{% endif %}">
 {% endif %}
 


### PR DESCRIPTION
fieldset definition can have "description" field beside "fields" to describe those "section"

https://docs.djangoproject.com/en/3.2/ref/contrib/admin/

"
A string of optional extra text to be displayed at the top of each fieldset, under the heading of the fieldset. This string is not rendered for TabularInline due to its layout.
"