### PR TITLE
Make Google CDN usage optional for fonts

### DIFF
--- a/jazzmin/settings.py
+++ b/jazzmin/settings.py
@@ -74,6 +74,8 @@ DEFAULT_SETTINGS: Dict[str, Any] = {
     # Relative paths to custom CSS/JS scripts (must be present in static files)
     "custom_css": None,
     "custom_js": None,
+    # Whether to link font from fonts.googleapis.com (use custom_css to supply font otherwise)
+    "use_google_fonts_cdn": True,
     # Whether to show the UI customizer on the sidebar
     "show_ui_builder": False,
     ###############

--- a/jazzmin/templates/admin/base.html
+++ b/jazzmin/templates/admin/base.html
@@ -40,8 +40,10 @@
     <link rel="shortcut icon" href="{% static jazzmin_settings.site_icon %}" type="image/png">
     <link rel="icon" href="{% static jazzmin_settings.site_icon %}" sizes="32x32" type="image/png">
 
+    {% if jazzmin_settings.use_google_fonts_cdn %}
     <!-- Google Font: Source Sans Pro -->
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700" rel="stylesheet">
+    {% endif %}
 
     {% block extrastyle %} {% endblock %}
     {% block extrahead %} {% endblock %}


### PR DESCRIPTION
This adds a setting `use_google_fonts_cdn` that allows the server admin to switch off the automatic include of font resources from fonts.googleapis.com . In this case, `custom_css` can be used to supply fonts. This allows changing the font in use, or simply serving the Google font locally.

Closes #347