### PR TITLE
Remove pr-2 from user and language selector to fix uneven right size of the focus pseudo-class

### DIFF
--- a/jazzmin/templates/admin/base.html
+++ b/jazzmin/templates/admin/base.html
@@ -121,7 +121,7 @@
 
                     <li class="nav-item dropdown">
                         <a class="nav-link btn" data-toggle="dropdown" href="#" title="Choose language">
-                            <i class="fas fa-globe pr-2" aria-hidden="true"></i>
+                            <i class="fas fa-globe" aria-hidden="true"></i>
                         </a>
                         <div class="dropdown-menu dropdown-menu-lg dropdown-menu-left" id="jazzy-languagemenu">
                             <form action="{% url 'set_language' %}" method="post">
@@ -145,7 +145,7 @@
 
                 <li class="nav-item dropdown">
                     <a class="nav-link btn" data-toggle="dropdown" href="#" title="{{ request.user }}">
-                        <i class="far fa-user pr-2" aria-hidden="true"></i>
+                        <i class="far fa-user" aria-hidden="true"></i>
                     </a>
                     <div class="dropdown-menu dropdown-menu-lg dropdown-menu-left" id="jazzy-usermenu">
                         <span class="dropdown-header">{% trans 'Account' %}</span>


### PR DESCRIPTION
This does not solve any open issue but I think is a fix to take in account.

This fix is meant to fix the uneven padding on the top right user and language buttons.

It might also be addressed by changing to px-1 instead of removing pr-2, in case I'm missing any reason for it to be there

Hope this small grain of sand helps