### PR TITLE
Add fieldset classes onto sensible element in changeform templates

### DIFF
--- a/jazzmin/templates/jazzmin/includes/carousel.html
+++ b/jazzmin/templates/jazzmin/includes/carousel.html
@@ -25,7 +25,7 @@
     </ol>
     <div class="carousel-inner">
         {% for fieldset in forms %}
-            <div class="carousel-item {% if forloop.first %}active{% endif %}" data-carouselid="{{ forloop.counter0 }}" data-label="{{ fieldset.name|default:general_tab|capfirst }}" data-target="#{{ fieldset.name|default:general_tab|unicode_slugify }}-tab">
+            <div class="carousel-item {% if forloop.first %}active{% endif %} {{ fieldset.classes }}" data-carouselid="{{ forloop.counter0 }}" data-label="{{ fieldset.name|default:general_tab|capfirst }}" data-target="#{{ fieldset.name|default:general_tab|unicode_slugify }}-tab">
                 {% if fieldset.is_inline %}
                     {% include fieldset.opts.template with inline_admin_formset=fieldset %}
                 {% else %}

--- a/jazzmin/templates/jazzmin/includes/collapsible.html
+++ b/jazzmin/templates/jazzmin/includes/collapsible.html
@@ -4,7 +4,7 @@
 
 <div id="jazzy-collapsible">
     {% for fieldset in forms %}
-        <div class="card card-default">
+        <div class="card card-default {{ fieldset.classes }}">
             <div class="card-header collapsible-header" data-toggle="collapse" data-parent="#jazzy-collapsible" data-target="#{{ fieldset.name|default:general_tab|unicode_slugify }}-tab">
                 <h4 class="card-title">
                     {{ fieldset.name|default:general_tab }}

--- a/jazzmin/templates/jazzmin/includes/horizontal_tabs.html
+++ b/jazzmin/templates/jazzmin/includes/horizontal_tabs.html
@@ -14,7 +14,7 @@
 
 <div class="tab-content">
     {% for fieldset in forms %}
-        <div id="{{ fieldset.name|default:general_tab|unicode_slugify }}-tab" class="tab-pane fade{% if forloop.first %} active show{% endif %}" role="tabpanel" aria-labelledby="{{ fieldset.name|default:general_tab|unicode_slugify }}-tab">
+        <div id="{{ fieldset.name|default:general_tab|unicode_slugify }}-tab" class="tab-pane fade{% if forloop.first %} active show{% endif %} {{ fieldset.classes }}" role="tabpanel" aria-labelledby="{{ fieldset.name|default:general_tab|unicode_slugify }}-tab">
             {% if fieldset.is_inline %}
                 {% include fieldset.opts.template with inline_admin_formset=fieldset %}
             {% else %}

--- a/jazzmin/templates/jazzmin/includes/single.html
+++ b/jazzmin/templates/jazzmin/includes/single.html
@@ -4,7 +4,7 @@
 {% for fieldset in forms %}
     {% if fieldset.is_inline %}
         {% if adminform|has_fieldsets %}
-            <div class="card">
+            <div class="card {{ fieldset.classes }}">
                 <div class="card-header">
                     {{ fieldset.name }}
                 </div>

--- a/jazzmin/templates/jazzmin/includes/vertical_tabs.html
+++ b/jazzmin/templates/jazzmin/includes/vertical_tabs.html
@@ -15,7 +15,7 @@
     <div class="col-7 col-sm-9">
         <div class="tab-content">
             {% for fieldset in forms %}
-                <div class="tab-pane fade {% if forloop.first %}show active{% endif %}" id="{{ fieldset.name|default:general_tab|unicode_slugify }}-tab" role="tabpanel">
+                <div class="tab-pane fade {% if forloop.first %}show active{% endif %} {{ fieldset.classes }}" id="{{ fieldset.name|default:general_tab|unicode_slugify }}-tab" role="tabpanel">
                     {% if fieldset.is_inline %}
                         {% include fieldset.opts.template with inline_admin_formset=fieldset %}
                     {% else %}


### PR DESCRIPTION
Aims to pass admin fieldset classes through to rendered fieldsets, see https://github.com/farridav/django-jazzmin/issues/370