### PR TITLE
Fix for related objects inline edit/delete buttons

### DIFF
--- a/jazzmin/static/jazzmin/js/change_form.js
+++ b/jazzmin/static/jazzmin/js/change_form.js
@@ -134,7 +134,15 @@
         else if ($carousel.length) { handleCarousel($carousel); }
         else if ($collapsible.length) { handleCollapsible($collapsible); }
 
-        applySelect2()
+        applySelect2();
+
+        $('body').on('change', '.related-widget-wrapper select', function(e) {
+            const event = $.Event('django:update-related');
+            $(this).trigger(event);
+            if (!event.isDefaultPrevented() && typeof(window.updateRelatedObjectLinks) !== 'undefined') {
+                updateRelatedObjectLinks(this);
+            }
+        });
     });
 
     // Apply select2 to all select boxes when new inline row is created


### PR DESCRIPTION
After select2 is applied to the related objects select inputs, the event
that enables/disables the edit and delete buttons next to the select is
not being triggered. Which makes it impossible to click those buttons
and open the popups
This code rebinds the change event after applying select2.