### PR TITLE
Support password reset views

### DIFF
--- a/jazzmin/templates/admin/login.html
+++ b/jazzmin/templates/admin/login.html
@@ -55,6 +55,16 @@
                 </div>
             </div>
         </div>
+        {% url 'admin_password_reset' as password_reset_url %}
+        {% if password_reset_url %}
+            <div class="mb-3">
+                <div class="password-reset-link" style="text-align: center;">
+                    <a href="{{ password_reset_url }}">
+                        {% trans 'Forgotten your password or username?' %}
+                    </a>
+                </div>
+            </div>
+        {% endif %}
         <div class="row">
             <div class="col-12">
                 <button type="submit" class="btn {{ jazzmin_ui.button_classes.primary }} btn-block">

--- a/jazzmin/templates/admin/login.html
+++ b/jazzmin/templates/admin/login.html
@@ -1,135 +1,66 @@
-{% load i18n static jazzmin admin_urls %}
-{% get_current_language as LANGUAGE_CODE %}
-{% get_current_language_bidi as LANGUAGE_BIDI %}
+{% extends "registration/base.html" %}
+
+{% load i18n jazzmin %}
 {% get_jazzmin_settings request as jazzmin_settings %}
 {% get_jazzmin_ui_tweaks as jazzmin_ui %}
 
-<!DOCTYPE html>
-<html lang="{{ LANGUAGE_CODE|default:"en-us" }}" {% if LANGUAGE_BIDI %}dir="rtl"{% endif %}>
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="x-ua-compatible" content="ie=edge">
-
-    <title>{% block title %}{{ title }} | {% trans 'Log in again' %}{% endblock %}</title>
-
-    <!-- Font Awesome Icons -->
-    <link rel="stylesheet" href="{% static "vendor/fontawesome-free/css/all.min.css" %}">
-
-    <!-- Bootstrap and adminLTE -->
-    <link rel="stylesheet" href="{% static "vendor/adminlte/css/adminlte.min.css" %}">
-
-    <!-- Bootswatch theme -->
-    {% if jazzmin_ui.theme.name != 'default' %}
-        <link rel="stylesheet" href="{{ jazzmin_ui.theme.src }}" id="jazzmin-theme" />
-    {% endif %}
-
-    {% if jazzmin_ui.dark_mode_theme %}
-        <link rel="stylesheet" href="{{ jazzmin_ui.dark_mode_theme.src }}" id="jazzmin-dark-mode-theme" media="(prefers-color-scheme: dark)"/>
-    {% endif %}
-
-    <!-- Custom fixes for django -->
-    <link rel="stylesheet" href="{% static "jazzmin/css/main.css" %}">
-
-    {% if jazzmin_settings.custom_css %}
-        <!-- Custom CSS -->
-        <link rel="stylesheet" href="{% static jazzmin_settings.custom_css %}">
-    {% endif %}
-
-    <!-- favicons -->
-    <link rel="shortcut icon" href="{% static jazzmin_settings.site_icon %}" type="image/png">
-    <link rel="icon" href="{% static jazzmin_settings.site_icon %}" sizes="32x32" type="image/png">
-
-    <!-- Google Font: Source Sans Pro -->
-    <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700" rel="stylesheet">
-
-    {% block extrastyle %} {% endblock %}
-    {% block extrahead %} {% endblock %}
-</head>
-<body class="hold-transition jazzmin-login-page">
-
-<div class="login-box">
-    <div class="login-logo">
-        <h1><img src="{% static jazzmin_settings.site_logo %}" alt="{{ jazzmin_settings.site_header }}"></h1>
-    </div>
-
-    <div class="card">
-        <div class="card-body">
-            <p class="login-box-msg">{{ jazzmin_settings.welcome_sign }}</p>
-            <form action="{{ app_path }}" method="post">
-                {% csrf_token %}
-                {% if user.is_authenticated %}
-                    <p class="errornote">
-                        <div class="callout callout-danger">
-                            <p>
-                                {% blocktrans trimmed %}
-                                    You are authenticated as {{ username }}, but are not authorized to
-                                    access this page. Would you like to login to a different account?
-                                {% endblocktrans %}
-                            </p>
-                        </div>
+{% block content %}
+    <p class="login-box-msg">{{ jazzmin_settings.welcome_sign }}</p>
+    <form action="{{ app_path }}" method="post">
+        {% csrf_token %}
+        {% if user.is_authenticated %}
+            <p class="errornote">
+                <div class="callout callout-danger">
+                    <p>
+                        {% blocktrans trimmed %}
+                            You are authenticated as {{ username }}, but are not authorized to
+                            access this page. Would you like to login to a different account?
+                        {% endblocktrans %}
                     </p>
-                {% endif %}
-                {% if form.errors %}
-
-                    {% if form.username.errors %}
-                    <div class="callout callout-danger">
-                        <p>{{ form.username.label }}: {{ form.username.errors|join:', ' }}</p>
-                    </div>
-                    {% endif %}
-
-                    {% if form.password.errors %}
-                    <div class="callout callout-danger">
-                        <p>{{ form.password.label }}: {{ form.password.errors|join:', ' }}</p>
-                    </div>
-                    {% endif %}
-
-                    {% if form.non_field_errors %}
-                    <div class="callout callout-danger">
-                        {% for error in form.non_field_errors %}
-                            <p>{{ error }}</p>
-                        {% endfor %}
-                    </div>
-                    {% endif %}
-
-                {% endif %}
-                <div class="input-group mb-3">
-                    <input type="text" name="username" class="form-control" placeholder="{{ form.username.label }}" required>
-                    <div class="input-group-append">
-                        <div class="input-group-text">
-                            <span class="fas fa-user"></span>
-                        </div>
-                    </div>
                 </div>
-                <div class="input-group mb-3">
-                    <input type="password" name="password" class="form-control" placeholder="{{ form.password.label }}" required>
-                    <div class="input-group-append">
-                        <div class="input-group-text">
-                            <span class="fas fa-lock"></span>
-                        </div>
-                    </div>
+            </p>
+        {% endif %}
+        {% if form.errors %}
+            {% if form.username.errors %}
+                <div class="callout callout-danger">
+                    <p>{{ form.username.label }}: {{ form.username.errors|join:', ' }}</p>
                 </div>
-                <div class="row">
-                    <div class="col-12">
-                        <button type="submit" class="btn {{ jazzmin_ui.button_classes.primary }} btn-block">{% trans "Log in" %}</button>
-                    </div>
+            {% endif %}
+            {% if form.password.errors %}
+                <div class="callout callout-danger">
+                    <p>{{ form.password.label }}: {{ form.password.errors|join:', ' }}</p>
                 </div>
-            </form>
-
+            {% endif %}
+            {% if form.non_field_errors %}
+                <div class="callout callout-danger">
+                    {% for error in form.non_field_errors %}
+                        <p>{{ error }}</p>
+                    {% endfor %}
+                </div>
+            {% endif %}
+        {% endif %}
+        <div class="input-group mb-3">
+            <input type="text" name="username" class="form-control" placeholder="{{ form.username.label }}" required>
+            <div class="input-group-append">
+                <div class="input-group-text">
+                    <span class="fas fa-user"></span>
+                </div>
+            </div>
         </div>
-    </div>
-</div>
-
-<!-- jQuery -->
-<script src="{% static "admin/js/vendor/jquery/jquery.js" %}"></script>
-<!-- Bootstrap 4 -->
-<script src="{% static 'vendor/bootstrap/js/bootstrap.min.js' %}"></script>
-<!-- AdminLTE App -->
-<script src="{% static 'vendor/adminlte/js/adminlte.min.js' %}"></script>
-
-{% if jazzmin_settings.custom_js %}
-<script src="{% static jazzmin_settings.custom_js %}"></script>
-{% endif %}
-
-</body>
-</html>
+        <div class="input-group mb-3">
+            <input type="password" name="password" class="form-control" placeholder="{{ form.password.label }}" required>
+            <div class="input-group-append">
+                <div class="input-group-text">
+                    <span class="fas fa-lock"></span>
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-12">
+                <button type="submit" class="btn {{ jazzmin_ui.button_classes.primary }} btn-block">
+                    {% trans "Log in" %}
+                </button>
+            </div>
+        </div>
+    </form>
+{% endblock %}

--- a/jazzmin/templates/registration/base.html
+++ b/jazzmin/templates/registration/base.html
@@ -1,0 +1,75 @@
+{% load i18n static jazzmin admin_urls %}
+{% get_current_language as LANGUAGE_CODE %}
+{% get_current_language_bidi as LANGUAGE_BIDI %}
+{% get_jazzmin_settings request as jazzmin_settings %}
+{% get_jazzmin_ui_tweaks as jazzmin_ui %}
+
+<!DOCTYPE html>
+<html lang="{{ LANGUAGE_CODE|default:"en-us" }}" {% if LANGUAGE_BIDI %}dir="rtl"{% endif %}>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+
+    <title>{% block title %}{{ title }} | {{ jazzmin_settings.site_title }}{% endblock %}</title>
+
+    <!-- Font Awesome Icons -->
+    <link rel="stylesheet" href="{% static "vendor/fontawesome-free/css/all.min.css" %}">
+
+    <!-- Bootstrap and adminLTE -->
+    <link rel="stylesheet" href="{% static "vendor/adminlte/css/adminlte.min.css" %}">
+
+    <!-- Bootswatch theme -->
+    {% if jazzmin_ui.theme.name != 'default' %}
+        <link rel="stylesheet" href="{{ jazzmin_ui.theme.src }}" id="jazzmin-theme" />
+    {% endif %}
+
+    {% if jazzmin_ui.dark_mode_theme %}
+        <link rel="stylesheet" href="{{ jazzmin_ui.dark_mode_theme.src }}" id="jazzmin-dark-mode-theme" media="(prefers-color-scheme: dark)"/>
+    {% endif %}
+
+    <!-- Custom fixes for django -->
+    <link rel="stylesheet" href="{% static "jazzmin/css/main.css" %}">
+
+    {% if jazzmin_settings.custom_css %}
+        <!-- Custom CSS -->
+        <link rel="stylesheet" href="{% static jazzmin_settings.custom_css %}">
+    {% endif %}
+
+    <!-- favicons -->
+    <link rel="shortcut icon" href="{% static jazzmin_settings.site_icon %}" type="image/png">
+    <link rel="icon" href="{% static jazzmin_settings.site_icon %}" sizes="32x32" type="image/png">
+
+    <!-- Google Font: Source Sans Pro -->
+    <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700" rel="stylesheet">
+
+    {% block extrastyle %} {% endblock %}
+    {% block extrahead %} {% endblock %}
+</head>
+<body class="hold-transition jazzmin-login-page">
+
+<div class="login-box">
+    <div class="login-logo">
+        <h1><img src="{% static jazzmin_settings.site_logo %}" alt="{{ jazzmin_settings.site_header }}"></h1>
+    </div>
+
+    <div class="card">
+        <div class="card-body">
+            {% block content %} {% endblock %}
+        </div>
+    </div>
+</div>
+
+<!-- jQuery -->
+<script src="{% static "admin/js/vendor/jquery/jquery.js" %}"></script>
+<!-- Bootstrap 4 -->
+<script src="{% static 'vendor/bootstrap/js/bootstrap.min.js' %}"></script>
+<!-- AdminLTE App -->
+<script src="{% static 'vendor/adminlte/js/adminlte.min.js' %}"></script>
+
+{% if jazzmin_settings.custom_js %}
+    <script src="{% static jazzmin_settings.custom_js %}"></script>
+{% endif %}
+
+</body>
+</html>

--- a/jazzmin/templates/registration/password_reset_complete.html
+++ b/jazzmin/templates/registration/password_reset_complete.html
@@ -1,0 +1,14 @@
+{% extends "registration/base.html" %}
+
+{% load i18n %}
+
+{% block content %}
+    <p class="login-box-msg">{% translate "Your password has been set.  You may go ahead and log in now." %}</p>
+    <div class="row">
+        <div class="col-12">
+            <a href="{{ login_url }}">
+                <button class="btn {{ jazzmin_ui.button_classes.primary }} btn-block">{% translate 'Log in' %}</button>
+            </a>
+        </div>
+    </div>
+{% endblock %}

--- a/jazzmin/templates/registration/password_reset_confirm.html
+++ b/jazzmin/templates/registration/password_reset_confirm.html
@@ -1,0 +1,60 @@
+{% extends "registration/base.html" %}
+
+{% load i18n %}
+
+{% block content %}
+    {% if validlink %}
+        <p class="login-box-msg">
+            {% translate "Please enter your new password twice so we can verify you typed it in correctly." %}
+        </p>
+        <form method="post">{% csrf_token %}
+            {% if form.errors %}
+                {% if form.new_password1.errors %}
+                    <div class="callout callout-danger">
+                        <p>{{ form.new_password1.label }}: {{ form.new_password1.errors|join:', ' }}</p>
+                    </div>
+                {% endif %}
+                {% if form.new_password2.errors %}
+                    <div class="callout callout-danger">
+                        <p>{{ form.new_password2.label }}: {{ form.new_password2.errors|join:', ' }}</p>
+                    </div>
+                {% endif %}
+                {% if form.non_field_errors %}
+                    <div class="callout callout-danger">
+                        {% for error in form.non_field_errors %}
+                            <p>{{ error }}</p>
+                        {% endfor %}
+                    </div>
+                {% endif %}
+            {% endif %}
+            <input class="hidden" autocomplete="username" value="{{ form.user.get_username }}">
+            <div class="input-group mb-3">
+                <input type="password" name="new_password1" class="form-control" placeholder="{{ form.new_password1.label }}" required>
+                <div class="input-group-append">
+                    <div class="input-group-text">
+                        <span class="fas fa-lock"></span>
+                    </div>
+                </div>
+            </div>
+            <div class="input-group mb-3">
+                <input type="password" name="new_password2" class="form-control" placeholder="{{ form.new_password2.label }}" required>
+                <div class="input-group-append">
+                    <div class="input-group-text">
+                        <span class="fas fa-lock"></span>
+                    </div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-12">
+                    <button type="submit" class="btn {{ jazzmin_ui.button_classes.primary }} btn-block">
+                        {% translate 'Change my password' %}
+                    </button>
+                </div>
+            </div>
+        </form>
+    {% else %}
+        <p>
+            {% translate "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset." %}
+        </p>
+    {% endif %}
+{% endblock %}

--- a/jazzmin/templates/registration/password_reset_done.html
+++ b/jazzmin/templates/registration/password_reset_done.html
@@ -1,0 +1,20 @@
+{% extends "registration/base.html" %}
+
+{% load i18n %}
+
+{% block content %}
+    <p>
+        {% blocktrans trimmed %}
+            We’ve emailed you instructions for setting your password,
+            if an account exists with the email you entered.
+            You should receive them shortly.
+        {% endblocktrans %}
+    </p>
+    <p>
+        {% blocktrans trimmed %}
+            If you don’t receive an email, please make sure
+            you’ve entered the address you registered with,
+            and check your spam folder.
+        {% endblocktrans %}
+    </p>
+{% endblock %}

--- a/jazzmin/templates/registration/password_reset_form.html
+++ b/jazzmin/templates/registration/password_reset_form.html
@@ -1,0 +1,46 @@
+{% extends "registration/base.html" %}
+
+{% load i18n jazzmin %}
+{% get_jazzmin_ui_tweaks as jazzmin_ui %}
+
+{% block content %}
+    <p class="login-box-msg">
+        {% blocktrans trimmed %}
+            Forgotten your password?
+            Enter your email address below, and we’ll
+            email instructions for setting a new one.
+        {% endblocktrans %}
+    </p>
+    <form method="post">
+        {% csrf_token %}
+        {% if form.errors %}
+            {% if form.email.errors %}
+                <div class="callout callout-danger">
+                    <p>{{ form.email.label }}: {{ form.email.errors|join:', ' }}</p>
+                </div>
+            {% endif %}
+            {% if form.non_field_errors %}
+                <div class="callout callout-danger">
+                    {% for error in form.non_field_errors %}
+                        <p>{{ error }}</p>
+                    {% endfor %}
+                </div>
+            {% endif %}
+        {% endif %}
+        <div class="input-group mb-3">
+            <input type="text" name="email" class="form-control" placeholder="{{ form.email.label }}" required>
+            <div class="input-group-append">
+                <div class="input-group-text">
+                    <span class="fas fa-envelope"></span>
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-12">
+                <button type="submit" class="btn {{ jazzmin_ui.button_classes.primary }} btn-block">
+                    {% translate 'Reset my password' %}
+                </button>
+            </div>
+        </div>
+    </form>
+{% endblock %}

--- a/tests/test_admin_views.py
+++ b/tests/test_admin_views.py
@@ -17,7 +17,10 @@ def test_login(client, admin_user):
     templates_used = [t.name for t in response.templates]
 
     assert response.status_code == 200
-    assert templates_used == ["admin/login.html"]
+    assert templates_used == [
+        "admin/login.html",
+        "registration/base.html",
+    ]
 
     response = client.post(
         url + "?next=/admin/",

--- a/tests/test_admin_views.py
+++ b/tests/test_admin_views.py
@@ -1,3 +1,4 @@
+import re
 import django
 import pytest
 from jazzmin.compat import reverse
@@ -44,6 +45,71 @@ def test_logout(admin_client):
 
     assert response.status_code == 200
     assert templates_used == ["registration/logged_out.html"]
+
+
+@pytest.mark.django_db
+def test_reset_password(client, admin_user):
+    """
+    We can render the password reset views
+    """
+    # Step 1: Password reset form
+    url = reverse("admin_password_reset")
+
+    response = client.get(url)
+    templates_used = [t.name for t in response.templates]
+
+    assert response.status_code == 200
+    assert templates_used == [
+        "registration/password_reset_form.html",
+        "registration/base.html",
+    ]
+
+    # Step 2: Password reset done
+    response = client.post(
+        url,
+        data={"email": admin_user.email},
+        follow=True,
+    )
+    templates_used = [t.name for t in response.templates]
+
+    assert response.status_code == 200
+    assert response.resolver_match.url_name == "password_reset_done"
+    assert templates_used == [
+        "registration/password_reset_done.html",
+        "registration/base.html",
+    ]
+    assert "We’ve emailed you instructions for setting your password" in response.content.decode()
+
+    # Get password reset link from reset email
+    email = django.core.mail.outbox[0]
+    url = re.search(r"https?://[^/]*(/.*reset/\S*)", email.body).group(1)
+
+    # Step 3: Password reset confirm
+    response = client.get(url, follow=True)
+    templates_used = [t.name for t in response.templates]
+
+    assert response.status_code == 200
+    assert response.resolver_match.url_name == "password_reset_confirm"
+    assert templates_used == [
+        "registration/password_reset_confirm.html",
+        "registration/base.html",
+    ]
+
+    # Step 4: Password reset complete
+    response = client.post(
+        response.request["PATH_INFO"],
+        data={"username": admin_user.username, "new_password1": "new_password", "new_password2": "new_password"},
+        follow=True,
+    )
+    templates_used = [t.name for t in response.templates]
+
+    assert response.status_code == 200
+    assert response.resolver_match.url_name == "password_reset_complete"
+    assert templates_used == [
+        "registration/password_reset_complete.html",
+        "registration/base.html",
+    ]
+    assert "Your password has been set." in response.content.decode()
 
 
 @pytest.mark.django_db

--- a/tests/test_app/library/urls.py
+++ b/tests/test_app/library/urls.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin, messages
+from django.contrib.auth import views as auth_views
 from django.http import HttpResponseRedirect
 from django.urls import path, re_path, reverse
 from django.views.generic import RedirectView
@@ -30,7 +31,29 @@ urlpatterns = [
     path("i18n/", include("django.conf.urls.i18n")),
 ]
 
-urlpatterns += i18n_patterns(path("admin/", admin.site.urls))
+urlpatterns += i18n_patterns(
+    path(
+        "admin/password_reset/",
+        auth_views.PasswordResetView.as_view(),
+        name="admin_password_reset",
+    ),
+    path(
+        "admin/password_reset/done/",
+        auth_views.PasswordResetDoneView.as_view(),
+        name="password_reset_done",
+    ),
+    path(
+        "reset/<uidb64>/<token>/",
+        auth_views.PasswordResetConfirmView.as_view(),
+        name="password_reset_confirm",
+    ),
+    path(
+        "reset/done/",
+        auth_views.PasswordResetCompleteView.as_view(),
+        name="password_reset_complete",
+    ),
+    path("admin/", admin.site.urls),
+)
 
 if settings.DEBUG:
     urlpatterns.append(


### PR DESCRIPTION
Thanks for your project! We really like the design, however we miss the possibility to reset passwords for our users.

Since PR #345 did not cover the complete password reset process and seems to be abandoned, I decided to take a shot at this topic.

### Suggested changes:
- Generalize login template (make it possible to reuse the design of the login form for other non-authenticated views)
- Add link to password reset to login form (fixes #387)
- Add templates for password reset (fixes #388)
- Add tests for password reset views/templates

@farridav Thanks in advance for your feedback! In PR #345, you suggested to add a setting for the name of the password reset view, however in the [default template](https://github.com/django/django/blob/abfdb4d7f384fb06ed9b7ca37b548542df7b5dda/django/contrib/admin/templates/admin/login.html#L56-L61), the view name is hardcoded as well, so I think it's fine to adopt this for django-jazzmin. If you still think a setting is required, I can add this to this PR if you want.