### PR TITLE
Add login_logo settings to differentiate site and login logo

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,9 @@ JAZZMIN_SETTINGS = {
 
     # Logo to use for your site, must be present in static files, used for brand on top left
     "site_logo": "books/img/logo.png",
+    
+    # Logo to use for your site, must be present in static files, used for brand on login screen logo (defaults to None)
+    "login_logo": None,
 
     # CSS classes that are applied to the logo above
     "site_logo_classes": "img-circle",

--- a/jazzmin/settings.py
+++ b/jazzmin/settings.py
@@ -18,6 +18,9 @@ DEFAULT_SETTINGS: Dict[str, Any] = {
     "site_brand": None,
     # Relative path to logo for your site, used for brand on top left (must be present in static files)
     "site_logo": "vendor/adminlte/img/AdminLTELogo.png",
+    # Relative path to logo for your site, used for brand on login screen.
+    # (must be present in static files) (will default to site_logo)
+    "login_logo": None,
     # CSS classes that are applied to the logo
     "site_logo_classes": "img-circle",
     # Relative path to a favicon for your site, will default to site_logo if absent (ideally 32x32 px)

--- a/jazzmin/templates/registration/base.html
+++ b/jazzmin/templates/registration/base.html
@@ -50,7 +50,15 @@
 
 <div class="login-box">
     <div class="login-logo">
-        <h1><img src="{% static jazzmin_settings.site_logo %}" alt="{{ jazzmin_settings.site_header }}"></h1>
+        <h1>
+            <img class="img-responsive" src="
+                {% if jazzmin_settings.login_logo %}
+                    {% static jazzmin_settings.login_logo %}
+                {% else %}
+                    {% static jazzmin_settings.site_logo %}
+                {% endif %}
+            " alt="{{ jazzmin_settings.site_header }}">
+        </h1>
     </div>
 
     <div class="card">

--- a/tests/test_app/library/settings.py
+++ b/tests/test_app/library/settings.py
@@ -125,6 +125,9 @@ JAZZMIN_SETTINGS: Dict[str, Any] = {
     "site_header": "Library",
     # Logo to use for your site, must be present in static files, used for brand on top left
     "site_logo": "books/img/logo.png",
+    # Logo to use for your site, must be present in static files, used for brand on login screen
+    # (Defaults to site_logo if absent or None)
+    "login_logo": None,
     # CSS classes that are applied to the logo
     "site_logo_classes": None,
     # Relative path to a favicon for your site, will default to site_logo if absent (ideally 32x32 px)


### PR DESCRIPTION
Changes will satisfy use cases where you have two different logos one for site brand and one for login: 
![wordmark](https://user-images.githubusercontent.com/56314705/161371568-6b20a41b-3774-48f1-8cee-e55287697c02.png)

![symbol](https://user-images.githubusercontent.com/56314705/161371586-7cdb195d-fdd4-4d18-88f3-7f38a5121ef9.png)

