### PR TITLE
Use fixed width for registration templates (fixes #318)

### DIFF
--- a/jazzmin/static/jazzmin/css/main.css
+++ b/jazzmin/static/jazzmin/css/main.css
@@ -735,8 +735,8 @@ body.no-sidebar .main-header {
 
 .login-box,
 .register-box {
-    width: auto;
-    max-width: 700px;
+    width: 500px;
+    max-width: 100%;
 }
 
 #jazzy-collapsible .collapsible-header:hover {


### PR DESCRIPTION
I'd also prefer a fixed width for the registration/login box, independently of the help text or error messages.

Fixes: #318