### PR TITLE
Workflow updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,5 @@
 ---
+
 name: Build
 on:
   push:
@@ -12,12 +13,12 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.1]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
     env:
       COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
@@ -25,6 +26,7 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
 
       - name: Install dependencies
         run: python -m pip install --upgrade pip tox tox-gh-actions
@@ -33,7 +35,7 @@ jobs:
         run: tox
 
       - name: cache deps
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.tox
           key: deps-${{ hashFiles('**/pyproject.toml') }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,12 +9,13 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v3
         with:
           python-version: '3.x'
+          cache: pip
 
       - name: Install dependencies
         run: python -m pip install --upgrade pip poetry

--- a/.github/workflows/heroku.yml
+++ b/.github/workflows/heroku.yml
@@ -9,12 +9,13 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v3
         with:
           python-version: '3.x'
+          cache: pip
 
       - name: Install dependencies
         run: python -m pip install --upgrade pip poetry
@@ -23,6 +24,7 @@ jobs:
         run: |
           poetry config repositories.testpypi https://test.pypi.org/legacy/
           poetry publish --build -r testpypi --username ${{ secrets.TESTPYPI_USERNAME }} --password ${{ secrets.TESTPYPI_PASSWORD }} || :
+
       - name: Deploy to Heroku
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}


### PR DESCRIPTION
1. Set `cache: pip` everywhere to speed up workflows a bit
2. Base actions version bump
3. Fix `3.10` version in lint workflow to use `latest` (and cached) version of python

Adding pip cache will result in less traffic on PyPi (but at this scale pertty much won't speed up perfomance). Same for using latest and cached by GitHub version of 3.10