### PR TITLE
Fix changelist results first column css class

### DIFF
--- a/jazzmin/templatetags/jazzmin.py
+++ b/jazzmin/templatetags/jazzmin.py
@@ -429,7 +429,11 @@ def header_class(header: Dict, forloop: Dict) -> str:
         header.get("descending"),
     )
 
-    if forloop["counter0"] == 0:
+    is_checkbox_column_conditions = (
+        forloop["counter0"] == 0,
+        header.get("class_attrib") == ' class="action-checkbox-column"',
+    )
+    if all(is_checkbox_column_conditions):
         classes.append("djn-checkbox-select-all")
 
     if not header["sortable"]:


### PR DESCRIPTION
Fixed https://github.com/farridav/django-jazzmin/issues/362

The first column in changelist results don't have to contain checkbox.
When django admin actions are deactivated, the class `djn-checkbox-select-all` is not needed.
When the column has checkboxes the class is always `action-checkbox-column`:
https://github.com/django/django/blob/stable/3.2.x/django/contrib/admin/templatetags/admin_list.py#L90

Before fix:
<img width="500" alt="Screenshot 2022-06-02 at 14 07 07" src="https://user-images.githubusercontent.com/985423/171619122-12f4dda6-c1a5-49c5-abcb-61d75a4cc6ac.png">

After fix:
<img width="500" alt="Screenshot 2022-06-02 at 14 09 37" src="https://user-images.githubusercontent.com/985423/171619118-ea1b17ac-41a9-4124-8317-1b7d9dc22b4e.png">