### PR TITLE
fix duplicated select2 on dal

### DIFF
--- a/jazzmin/static/jazzmin/js/change_form.js
+++ b/jazzmin/static/jazzmin/js/change_form.js
@@ -113,7 +113,7 @@
     function applySelect2() {
         // Apply select2 to any select boxes that don't yet have it
         // and are not part of the django's empty-form inline
-        const noSelect2 = '.empty-form select, .select2-hidden-accessible, .selectfilter, .selector-available select, .selector-chosen select';
+        const noSelect2 = '.empty-form select, .select2-hidden-accessible, .selectfilter, .selector-available select, .selector-chosen select, .noSelect2DAL';
         $('select').not(noSelect2).select2({ width: 'element' });
     }
 

--- a/jazzmin/static/jazzmin/js/change_list.js
+++ b/jazzmin/static/jazzmin/js/change_list.js
@@ -56,7 +56,7 @@
         $('.related-lookup').append('<i class="fa fa-search"></i>')
 
         // Allow for styling of selects
-        $('.actions select').addClass('form-control');
+        $('.actions select').addClass('form-control').select2({ width: 'element' });
 
         searchFilters();
     });


### PR DESCRIPTION
Add class to fix duplicated on auto-complete-light package. need to add on the autocomplete form the attribute as follows: attrs={'class': 'noSelect2DAL'}