### PR TITLE
Fix default_app_config warning using automatic appconfig discovery

### DIFF
--- a/jazzmin/__init__.py
+++ b/jazzmin/__init__.py
@@ -1,2 +1,7 @@
+
+import django
+
 version = "2.5.0"
-default_app_config = "jazzmin.apps.JazzminConfig"
+
+if django.VERSION < (3, 2):
+    default_app_config = "jazzmin.apps.JazzminConfig"


### PR DESCRIPTION
Based on Django documentation, from 3.2+ version:
"When the apps.py submodule exists and defines a single AppConfig subclass, Django now uses that configuration
automatically, so you can remove default_app_config."

(https://docs.djangoproject.com/en/3.2/releases/3.2/#automatic-appconfig-discovery)