### PR TITLE
Update field CSS

### DIFF
--- a/jazzmin/static/jazzmin/css/main.css
+++ b/jazzmin/static/jazzmin/css/main.css
@@ -205,11 +205,8 @@ table.dataTable thead .sorting_desc_disabled::after {
 .form-group div .vLargeTextField,
 .form-group div .vURLField,
 .form-group div .vBigIntegerField,
-.form-group div.field-duration input[type="text"],
-.form-group div.field-identifier input[type="text"],
-.form-group div.field-generic_ip_address input[type="text"],
-.form-group .field-null_boolean select,
-.form-group .field-file_path select {
+.form-group div input[type="text"],
+.form-group select {
     display: block;
     width: 100%;
 }
@@ -222,14 +219,9 @@ table.dataTable thead .sorting_desc_disabled::after {
 .vForeignKeyRawIdAdminField,
 .vDateField,
 .vTimeField,
-.field-float input[type="number"],
-.field-decimal input[type="number"],
-.field-time input[type="text"],
-.field-duration input[type="text"],
-.field-identifier input[type="text"],
-.field-generic_ip_address input[type="text"],
-.field-null_boolean select,
-.field-file_path select {
+input[type="number"],
+input[type="text"]
+{
     height: calc(2.25rem + 2px);
     padding: .375rem .75rem;
     font-size: 1rem;

--- a/jazzmin/static/jazzmin/css/main.css
+++ b/jazzmin/static/jazzmin/css/main.css
@@ -205,8 +205,8 @@ table.dataTable thead .sorting_desc_disabled::after {
 .form-group div .vLargeTextField,
 .form-group div .vURLField,
 .form-group div .vBigIntegerField,
-.form-group div input[type="text"],
-.form-group select {
+.form-group div input[type="text"]
+{
     display: block;
     width: 100%;
 }


### PR DESCRIPTION
# The problem

So there were some css declarations that were searching for `field-{type}` classes, but in Django we're using `field-{field_name}`. So that's why there were no default styles for fields not having any `v...Field` class attached to them (when there's a default widget for, like `IntegerField` which adds `vIntegerField`).
I removed those parts and now things like `DecimalField`, `GenericIPAddressField` and others are rendered with correct styles.

I also removed selects from `display: block` and `width: 100%` rule, becuase it was going out of bounds.

## Testing

As for testing, here's the model
```python
# Fields are chosen from the diff. Names are chosen to not conflict with types
class TestModel(models.Model):
    ip_field = models.GenericIPAddressField("IP")
    duration_field = models.DurationField("Duration")
    boolean_field = models.BooleanField("Null boolean", null=True)
    file_path_field = models.FilePathField("File path", path="./")
    file_field = models.FileField("File path")
```

### Django 2.2
**Before the change**
![image](https://user-images.githubusercontent.com/18076967/179248160-3938046e-869a-4c13-87c0-7b5c2184d581.png)
**After**
![image](https://user-images.githubusercontent.com/18076967/179248326-ac6707c8-4140-4352-9aee-c0711e4609b9.png)

### Django 3.0
**Before**
![image](https://user-images.githubusercontent.com/18076967/179248908-ddb6455a-bce6-4659-b0b2-af1c7690f6a3.png)
**After**
![image](https://user-images.githubusercontent.com/18076967/179248838-10ffdb14-a733-4999-ae26-8a9c2bdc714f.png)

### Django 4.0 (not even allowing NullBooleanField anymore)
**Before**
![image](https://user-images.githubusercontent.com/18076967/179249151-67bbc709-c856-4edf-8592-5dc7b03acc77.png)
**After**
![image](https://user-images.githubusercontent.com/18076967/179249223-67c6e064-906c-43de-8149-65b4b5554c06.png)

### Select width (all of the other fixed are already applied)
**Before**
![Screenshot from 2022-07-15 18-13-43](https://user-images.githubusercontent.com/18076967/179253808-1470c840-7191-4bad-9674-2efd05d3bb8d.png)
**After**
![Screenshot from 2022-07-15 18-15-35](https://user-images.githubusercontent.com/18076967/179253839-4e205fc8-c417-4dcf-bac3-46fd5b1f9b67.png)

