### PR TITLE
Center content in selects

### DIFF
--- a/jazzmin/static/jazzmin/css/main.css
+++ b/jazzmin/static/jazzmin/css/main.css
@@ -165,7 +165,9 @@ table.dataTable thead .sorting_desc_disabled::after {
 .select2-container .select2-selection--single {
     border: 1px solid #ced4da !important;
     min-height: 38px;
-    /* padding-top: 5px; */
+    /* Center text inside */
+    display: flex !important;
+    align-items: center;
 }
 
 .select2-container--default .select2-selection--single {
@@ -174,7 +176,7 @@ table.dataTable thead .sorting_desc_disabled::after {
 
 .select2-container--default .select2-selection--single .select2-selection__arrow {
     right: 5px !important;
-    top: 5px !important;
+    top: unset !important;
 }
 
 .select2-results__option {


### PR DESCRIPTION
- Vertically center text in selects
- Natively center arrow (remove hardcoded top value, use `unset`). Although this didn't change much - it's still a more native way to do this than hardcoding (didn't test on IE)

This is kind of a follow up on #405

Here's before and after (left and right respectively)
![Screenshot from 2022-07-15 19-24-52](https://user-images.githubusercontent.com/18076967/179267972-b39c077f-b0ad-4283-b042-af70d7dc82dc.png)
