### PR TITLE
Fix builds

### DIFF
--- a/jazzmin/__init__.py
+++ b/jazzmin/__init__.py
@@ -1,4 +1,3 @@
-
 import django
 
 version = "2.5.0"

--- a/jazzmin/templates/admin/includes/fieldset.html
+++ b/jazzmin/templates/admin/includes/fieldset.html
@@ -22,7 +22,7 @@
     <div class="form-group{% if line.fields|length_is:'1' and line.errors %} errors{% endif %}{% if not line.has_visible_field %} hidden{% endif %}{% for field in line %}{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% endfor %}">
         <div class="row">
             {% for field in line %}
-                <label class="{% if not line.fields|length_is:'1' and forloop.counter != 1 %}col-auto {% else %}col-sm-3 {% endif %}text-left" for={{ field.field.id_for_label }}>
+                <label class="{% if not line.fields|length_is:'1' and forloop.counter != 1 %}col-auto {% else %}col-sm-3 {% endif %}text-left" for="id_{{ field.field.name }}">
                     {{ field.field.label|capfirst }}
                     {% if field.field.field.required %}
                     <span class="text-red">* </span>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,20 +96,20 @@ show_missing = true
 legacy_tox_ini = """
 [tox]
 envlist =
-    django2-{py36,py37},
-    django3-{py36,py37,py38,py39},
-    django4-{py38,py39,py310},
+    django2-{python3.6,python3.7},
+    django3-{python3.6,python3.7,python3.8,python3.9},
+    django4-{python3.8,python3.9,python3.10},
     # run one of the tests again but with coverage
-    coveralls-django4-py310,
+    coveralls-django4-python3.10,
 skipsdist = True
 
 [gh-actions]
 python =
-    3.6: py36
-    3.7: py37
-    3.8: py38
-    3.9: py39
-    3.10: py310
+    3.6: python3.6
+    3.7: python3.7
+    3.8: python3.8
+    3.9: python3.9
+    3.10: python3.10
 
 [testenv]
 setenv =
@@ -132,7 +132,7 @@ deps =
     django3: Django<4
     django4: Django<5
 
-[testenv:coveralls-django4-py310]
+[testenv:coveralls-django4-python3.10]
 passenv = COVERALLS_REPO_TOKEN
 commands =
     - mypy jazzmin --ignore-missing-imports

--- a/tests/test_admin_views.py
+++ b/tests/test_admin_views.py
@@ -262,7 +262,7 @@ def test_detail(admin_client):
     if django.VERSION[0] == 4:
         expected_templates_used.update(
             {
-                'django/forms/div.html',
+                "django/forms/div.html",
                 "django/forms/errors/list/default.html",
                 "django/forms/errors/list/ul.html",
             }

--- a/tests/test_admin_views.py
+++ b/tests/test_admin_views.py
@@ -224,10 +224,9 @@ def test_detail(admin_client):
     if django.VERSION[0] == 4:
         expected_render_counts.update(
             {
-                "django/forms/default.html": 1,
-                "django/forms/errors/list/default.html": 1,
-                "django/forms/errors/list/ul.html": 55,
-                "django/forms/table.html": 1,
+                "django/forms/div.html": 1,
+                "django/forms/errors/list/default.html": 2,
+                "django/forms/errors/list/ul.html": 56,
             }
         )
 
@@ -263,10 +262,9 @@ def test_detail(admin_client):
     if django.VERSION[0] == 4:
         expected_templates_used.update(
             {
-                "django/forms/default.html",
+                'django/forms/div.html',
                 "django/forms/errors/list/default.html",
                 "django/forms/errors/list/ul.html",
-                "django/forms/table.html",
             }
         )
 
@@ -314,10 +312,9 @@ def test_list(admin_client):
     if django.VERSION[0] == 4:
         expected_render_counts.update(
             {
-                "django/forms/default.html": 1,
-                "django/forms/errors/list/default.html": 5,
-                "django/forms/errors/list/ul.html": 5,
-                "django/forms/table.html": 1,
+                "django/forms/div.html": 1,
+                "django/forms/errors/list/default.html": 6,
+                "django/forms/errors/list/ul.html": 6,
             }
         )
 
@@ -347,10 +344,9 @@ def test_list(admin_client):
     if django.VERSION[0] == 4:
         expected_templates.update(
             {
-                "django/forms/default.html",
+                "django/forms/div.html",
                 "django/forms/errors/list/default.html",
                 "django/forms/errors/list/ul.html",
-                "django/forms/table.html",
             }
         )
 


### PR DESCRIPTION
### 1. Revert #420

`{{ field.field }}` can be a dictionary which won't have `id_for_label`. You can see it in here https://github.com/farridav/django-jazzmin/blob/0c1d115f10ebcab347942cadc78e67d73340e2f6/tests/test_app/library/books/admin.py#L26 we use `__str__` as a part of the display which will result in django trying to lookup `id_for_field` from a dict.
![image](https://user-images.githubusercontent.com/18076967/183459050-c33dba28-4f75-4744-82c8-562bfa358f0b.png)

#### Note

I didn't notice any issues in manual testing, so this may be an issue with the test (although I also doubt it). I think it's safe to revert until we can fix it or fix the test.

### 2. Update tox's config to fix issues with `conda`/`pyenv`

Update `tox` section in `pyproject.toml` to fix `InterpreterNotFound` error. Check out [solution reference](https://github.com/tox-dev/tox/issues/378#issuecomment-413937359) (note that I'm not using `conda`, but `pyenv`).

This was the error:
```
└❯ tox
django2-py36 create: /home/dhvcc/PycharmProjects/django-jazzmin/.tox/django2-py36
ERROR: InterpreterNotFound: python3.6
django2-py37 create: /home/dhvcc/PycharmProjects/django-jazzmin/.tox/django2-py37
ERROR: InterpreterNotFound: python3.7
django3-py36 create: /home/dhvcc/PycharmProjects/django-jazzmin/.tox/django3-py36
ERROR: InterpreterNotFound: python3.6
django3-py37 create: /home/dhvcc/PycharmProjects/django-jazzmin/.tox/django3-py37
ERROR: InterpreterNotFound: python3.7
```
This seems to not be the case for `gh-actions` as they're using different containers for each python version

### 3. Update `render_counts` and `templates_used` for `django>4`

Not sure what made this fail honestly as we can see it **worked** before, but I had persistent fails with running UI tests for `django>4` (also shown in recent `gh-actions` build). So yeah, I just updated the values accordingly and now it seems to be working for me locally and for github actions runs.