### PR TITLE
django-autocomplete-light full support

### DIFF
--- a/jazzmin/static/jazzmin/js/change_form.js
+++ b/jazzmin/static/jazzmin/js/change_form.js
@@ -113,7 +113,7 @@
     function applySelect2() {
         // Apply select2 to any select boxes that don't yet have it
         // and are not part of the django's empty-form inline
-        const noSelect2 = '.empty-form select, .select2-hidden-accessible, .selectfilter, .selector-available select, .selector-chosen select, .noSelect2DAL';
+        const noSelect2 = '.empty-form select, .select2-hidden-accessible, .selectfilter, .selector-available select, .selector-chosen select, select[data-autocomplete-light-function=select2]';
         $('select').not(noSelect2).select2({ width: 'element' });
     }
 


### PR DESCRIPTION
.noSelect2DAL solution requires using attrs={'class': 'noSelect2DAL'} with every autocomplete widget declaration. It is not  intuitive or beautiful in any way. 

This patch fully fixes issue mentioned on issue #210 