### PR TITLE
Make use_google_fonts_cdn work with registration templates

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -124,6 +124,8 @@ JAZZMIN_SETTINGS = {
     # Relative paths to custom CSS/JS scripts (must be present in static files)
     "custom_css": None,
     "custom_js": None,
+    # Whether to link font from fonts.googleapis.com (use custom_css to supply font otherwise)
+    "use_google_fonts_cdn": True,
     # Whether to show the UI customizer on the sidebar
     "show_ui_builder": False,
 

--- a/jazzmin/templates/registration/base.html
+++ b/jazzmin/templates/registration/base.html
@@ -40,8 +40,10 @@
     <link rel="shortcut icon" href="{% static jazzmin_settings.site_icon %}" type="image/png">
     <link rel="icon" href="{% static jazzmin_settings.site_icon %}" sizes="32x32" type="image/png">
 
+    {% if jazzmin_settings.use_google_fonts_cdn %}
     <!-- Google Font: Source Sans Pro -->
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700" rel="stylesheet">
+    {% endif %}
 
     {% block extrastyle %} {% endblock %}
     {% block extrahead %} {% endblock %}


### PR DESCRIPTION
The `use_google_fonts_cdn` setting works great for the admin pages! However it seems that google fonts are still used in the registration pages (e.g. log out view, password reset view etc.). This PR should solve this issue.

Along the change itself, I've also updated the example setting documentation to reference this flag.