### PR TITLE
Fix non ascii characters beeing used in element IDs

### DIFF
--- a/jazzmin/templates/jazzmin/includes/carousel.html
+++ b/jazzmin/templates/jazzmin/includes/carousel.html
@@ -25,7 +25,7 @@
     </ol>
     <div class="carousel-inner">
         {% for fieldset in forms %}
-            <div class="carousel-item {% if forloop.first %}active{% endif %} {{ fieldset.classes }}" data-carouselid="{{ forloop.counter0 }}" data-label="{{ fieldset.name|default:general_tab|capfirst }}" data-target="#{{ fieldset.name|default:general_tab|unicode_slugify }}-tab">
+            <div class="carousel-item {% if forloop.first %}active{% endif %} {{ fieldset.classes }}" data-carouselid="{{ forloop.counter0 }}" data-label="{{ fieldset.name|default:general_tab|capfirst }}" data-target="#{{ fieldset.name|default:general_tab|slugify }}-tab">
                 {% if fieldset.is_inline %}
                     {% include fieldset.opts.template with inline_admin_formset=fieldset %}
                 {% else %}

--- a/jazzmin/templates/jazzmin/includes/collapsible.html
+++ b/jazzmin/templates/jazzmin/includes/collapsible.html
@@ -5,12 +5,12 @@
 <div id="jazzy-collapsible">
     {% for fieldset in forms %}
         <div class="card card-default {{ fieldset.classes }}">
-            <div class="card-header collapsible-header" data-toggle="collapse" data-parent="#jazzy-collapsible" data-target="#{{ fieldset.name|default:general_tab|unicode_slugify }}-tab">
+            <div class="card-header collapsible-header" data-toggle="collapse" data-parent="#jazzy-collapsible" data-target="#{{ fieldset.name|default:general_tab|slugify }}-tab">
                 <h4 class="card-title">
                     {{ fieldset.name|default:general_tab }}
                 </h4>
             </div>
-            <div id="{{ fieldset.name|default:general_tab|unicode_slugify }}-tab" class="panel-collapse in {% if forloop.first %}show{% else %}collapse{% endif %}">
+            <div id="{{ fieldset.name|default:general_tab|slugify }}-tab" class="panel-collapse in {% if forloop.first %}show{% else %}collapse{% endif %}">
                 <div class="card-body">
                     {% if fieldset.is_inline %}
                         {% include fieldset.opts.template with inline_admin_formset=fieldset %}

--- a/jazzmin/templates/jazzmin/includes/horizontal_tabs.html
+++ b/jazzmin/templates/jazzmin/includes/horizontal_tabs.html
@@ -6,7 +6,7 @@
 <ul class="nav nav-tabs mb-3" role="tablist" id="jazzy-tabs">
     {% for fieldset in forms %}
         <li class="nav-item">
-            <a class="nav-link{% if forloop.first %} active{% endif %}" data-toggle="pill" role="tab" aria-controls="{{ fieldset.name|default:general_tab|unicode_slugify }}-tab" aria-selected="{% if forloop.first %}true{% else %}false{% endif %}" href="#{{ fieldset.name|default:general_tab|unicode_slugify }}-tab">
+            <a class="nav-link{% if forloop.first %} active{% endif %}" data-toggle="pill" role="tab" aria-controls="{{ fieldset.name|default:general_tab|slugify }}-tab" aria-selected="{% if forloop.first %}true{% else %}false{% endif %}" href="#{{ fieldset.name|default:general_tab|slugify }}-tab">
                 {{ fieldset.name|default:general_tab }}
             </a>
         </li>
@@ -16,7 +16,7 @@
 
 <div class="tab-content">
     {% for fieldset in forms %}
-        <div id="{{ fieldset.name|default:general_tab|unicode_slugify }}-tab" class="tab-pane fade{% if forloop.first %} active show{% endif %} {{ fieldset.classes }}" role="tabpanel" aria-labelledby="{{ fieldset.name|default:general_tab|unicode_slugify }}-tab">
+        <div id="{{ fieldset.name|default:general_tab|slugify }}-tab" class="tab-pane fade{% if forloop.first %} active show{% endif %} {{ fieldset.classes }}" role="tabpanel" aria-labelledby="{{ fieldset.name|default:general_tab|slugify }}-tab">
             {% if fieldset.is_inline %}
                 {% include fieldset.opts.template with inline_admin_formset=fieldset %}
             {% else %}

--- a/jazzmin/templates/jazzmin/includes/vertical_tabs.html
+++ b/jazzmin/templates/jazzmin/includes/vertical_tabs.html
@@ -6,7 +6,7 @@
     <div class="col-5 col-sm-3">
         <div class="nav flex-column nav-tabs h-100" role="tablist" aria-orientation="vertical">
             {% for fieldset in forms %}
-                <a class="nav-link {% if forloop.first %}active{% endif %}" data-toggle="pill" href="#{{ fieldset.name|default:general_tab|unicode_slugify }}-tab" role="tab" aria-controls="{{ fieldset.name|default:general_tab|unicode_slugify }}-tab" aria-selected="{% if forloop.first %}true{% else %}false{% endif %}">
+                <a class="nav-link {% if forloop.first %}active{% endif %}" data-toggle="pill" href="#{{ fieldset.name|default:general_tab|slugify }}-tab" role="tab" aria-controls="{{ fieldset.name|default:general_tab|slugify }}-tab" aria-selected="{% if forloop.first %}true{% else %}false{% endif %}">
                     {{ fieldset.name|default:general_tab }}
                 </a>
             {% endfor %}
@@ -15,7 +15,7 @@
     <div class="col-7 col-sm-9">
         <div class="tab-content">
             {% for fieldset in forms %}
-                <div class="tab-pane fade {% if forloop.first %}show active{% endif %} {{ fieldset.classes }}" id="{{ fieldset.name|default:general_tab|unicode_slugify }}-tab" role="tabpanel">
+                <div class="tab-pane fade {% if forloop.first %}show active{% endif %} {{ fieldset.classes }}" id="{{ fieldset.name|default:general_tab|slugify }}-tab" role="tabpanel">
                     {% if fieldset.is_inline %}
                         {% include fieldset.opts.template with inline_admin_formset=fieldset %}
                     {% else %}


### PR DESCRIPTION
Hi!

The `unicode_slugify` filter is used to generate slugs from the display name of things like tabs. This variant keeps special, non-ascii characters such as accented characters.

However, the resulting slug is used as ID for some elements (like the content of tabbed menus), and using non-ascii characters in IDs can cause problems such as the inability to generate a URL that directly opens a specific tab. Such problems can easily be explained by the fact that IDs with special characters [don't seem to be supported by the W3C](https://www.w3.org/TR/html4/types.html#type-id).

Therefore, the ascii variant of this filter (ie: `slugify`) should be used instead.

Regards,
Pursuit