### PR TITLE
Dark-mode class in body missing

### DIFF
--- a/jazzmin/settings.py
+++ b/jazzmin/settings.py
@@ -304,7 +304,7 @@ def get_ui_tweaks() -> Dict:
         dark_mode_theme = "darkly"
 
     theme_body_classes = " theme-{}".format(theme)
-    if theme in DARK_THEMES:
+    if theme in DARK_THEMES or dark_mode_theme:
         theme_body_classes += " dark-mode"
 
     ret = {


### PR DESCRIPTION
.dark-mode in body is missing this check will ensure adding .dark-mode in body if dark-mode-theme is explicitly set.