### PR TITLE
Fix broken fa icons url

### DIFF
--- a/docs/bugs_and_features.md
+++ b/docs/bugs_and_features.md
@@ -38,5 +38,5 @@ Some useful links for feature development:
 
 - [https://adminlte.io/themes/v3/index3.html](https://adminlte.io/themes/v3/index3.html)
 - [https://adminlte.io/docs/3.0/index.html](https://adminlte.io/docs/3.0/index.html)
-- [Font awesome 5.13.0 free icons](https://fontawesome.com/icons?d=gallery&m=free&v=5.0.0,5.0.1,5.0.10,5.0.11,5.0.12,5.0.13,5.0.2,5.0.3,5.0.4,5.0.5,5.0.6,5.0.7,5.0.8,5.0.9,5.1.0,5.1.1,5.2.0,5.3.0,5.3.1,5.4.0,5.4.1,5.4.2,5.13.0,5.12.0,5.11.2,5.11.1,5.10.0,5.9.0,5.8.2,5.8.1,5.7.2,5.7.1,5.7.0,5.6.3,5.5.0,5.4.2)
+- [Font awesome 5.13.0 free icons](https://fontawesome.com/v5/search?o=r&m=free)
 - [https://getbootstrap.com/docs/4.5/getting-started/introduction/](https://getbootstrap.com/docs/4.5/getting-started/introduction/)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,7 +102,7 @@ JAZZMIN_SETTINGS = {
         }]
     },
 
-    # Custom icons for side menu apps/models See https://fontawesome.com/icons?d=gallery&m=free&v=5.0.0,5.0.1,5.0.10,5.0.11,5.0.12,5.0.13,5.0.2,5.0.3,5.0.4,5.0.5,5.0.6,5.0.7,5.0.8,5.0.9,5.1.0,5.1.1,5.2.0,5.3.0,5.3.1,5.4.0,5.4.1,5.4.2,5.13.0,5.12.0,5.11.2,5.11.1,5.10.0,5.9.0,5.8.2,5.8.1,5.7.2,5.7.1,5.7.0,5.6.3,5.5.0,5.4.2
+    # Custom icons for side menu apps/models See https://fontawesome.com/v5/search?o=r&m=free
     # for the full list of 5.13.0 free icon classes
     "icons": {
         "auth": "fas fa-users-cog",
@@ -219,7 +219,7 @@ Example:
             # url name e.g `admin:index`, relative urls e.g `/admin/index` or absolute urls e.g `https://domain.com/admin/index`
             "url": "make_messages",                 
             
-            # any font-awesome icon, see list here https://fontawesome.com/icons?d=gallery&m=free&v=5.0.0,5.0.1,5.0.10,5.0.11,5.0.12,5.0.13,5.0.2,5.0.3,5.0.4,5.0.5,5.0.6,5.0.7,5.0.8,5.0.9,5.1.0,5.1.1,5.2.0,5.3.0,5.3.1,5.4.0,5.4.1,5.4.2,5.13.0,5.12.0,5.11.2,5.11.1,5.10.0,5.9.0,5.8.2,5.8.1,5.7.2,5.7.1,5.7.0,5.6.3,5.5.0,5.4.2 (optional)
+            # any font-awesome icon, see list here https://fontawesome.com/v5/search?o=r&m=free
             "icon": "fas fa-comments",                  
             
             # a list of permissions the user must have to see this link (optional)

--- a/docs/development.md
+++ b/docs/development.md
@@ -57,7 +57,7 @@ You can serve the docs locally using `mkdocs serve -a localhost:8001` and visiti
 ## Translations
 Working with translations in jazzmin is, a bit unorthodox, as we are overriding djangos templates, so it looks like we have a lot of strings that need translating,
 but in-fact they already have translation strings in Django, heres the process for dealing with translations, though we recommend not adding new strings that need
-translating if possible, and use suitable iconography instead (See [Font Awesome 5.13.0 free icons](https://fontawesome.com/icons?d=gallery&m=free&v=5.0.0,5.0.1,5.0.10,5.0.11,5.0.12,5.0.13,5.0.2,5.0.3,5.0.4,5.0.5,5.0.6,5.0.7,5.0.8,5.0.9,5.1.0,5.1.1,5.2.0,5.3.0,5.3.1,5.4.0,5.4.1,5.4.2,5.13.0,5.12.0,5.11.2,5.11.1,5.10.0,5.9.0,5.8.2,5.8.1,5.7.2,5.7.1,5.7.0,5.6.3,5.5.0,5.4.2)),
+translating if possible, and use suitable iconography instead (See [Font Awesome 5.13.0 free icons](https://fontawesome.com/v5/search?o=r&m=free)),
 or use a string that is already translated upstream in Django.
 
 ### Adding a new language

--- a/jazzmin/settings.py
+++ b/jazzmin/settings.py
@@ -60,8 +60,7 @@ DEFAULT_SETTINGS: Dict[str, Any] = {
     # Custom links to append to side menu app groups, keyed on app name
     "custom_links": {},
     # Custom icons for side menu apps/models See the link below
-    # https://fontawesome.com/icons?d=gallery&m=free&v=5.0.0,5.0.1,5.0.10,5.0.11,5.0.12,5.0.13,5.0.2,5.0.3,5.0.4,5.0.5,5.0.6,5.0.7,5.0.8,5.0.9,5.1.0,
-    # 5.1.1,5.2.0,5.3.0,5.3.1,5.4.0,5.4.1,5.4.2,5.13.0,5.12.0,5.11.2,5.11.1,5.10.0,5.9.0,5.8.2,5.8.1,5.7.2,5.7.1,5.7.0,5.6.3,5.5.0,5.4.2
+    # https://fontawesome.com/v5/search?o=r&m=free
     # for the full list of 5.13.0 free icon classes
     "icons": {"auth": "fas fa-users-cog", "auth.user": "fas fa-user", "auth.Group": "fas fa-users"},
     # Icons that are used when one is not manually specified

--- a/tests/test_app/library/settings.py
+++ b/tests/test_app/library/settings.py
@@ -191,8 +191,7 @@ JAZZMIN_SETTINGS: Dict[str, Any] = {
         ]
     },
     # Custom icons for side menu apps/models See the link below
-    # https://fontawesome.com/icons?d=gallery&m=free&v=5.0.0,5.0.1,5.0.10,5.0.11,5.0.12,5.0.13,5.0.2,5.0.3,5.0.4,5.0.5,5.0.6,5.0.7,5.0.8,5.0.9,5.1.0,
-    # 5.1.1,5.2.0,5.3.0,5.3.1,5.4.0,5.4.1,5.4.2,5.13.0,5.12.0,5.11.2,5.11.1,5.10.0,5.9.0,5.8.2,5.8.1,5.7.2,5.7.1,5.7.0,5.6.3,5.5.0,5.4.2
+    # https://fontawesome.com/v5/search?o=r&m=free
     # for the full list of 5.13.0 free icon classes
     "icons": {
         "auth": "fas fa-users-cog",


### PR DESCRIPTION
Font Awesome has updated the docs, and the previous links are broken. This fix points to v5 doc.
There is a problem, tough. You can only filter by major version. So it will actually point to 5.15.4 instead of 5.13 :woman_shrugging: 