### PR TITLE
replace depcrecated command "length_is" with "length" Django 4 upwards

### DIFF
--- a/jazzmin/templates/admin/includes/fieldset.html
+++ b/jazzmin/templates/admin/includes/fieldset.html
@@ -19,16 +19,16 @@
 {% endif %}
 
     {% for line in fieldset %}
-    <div class="form-group{% if line.fields|length_is:'1' and line.errors %} errors{% endif %}{% if not line.has_visible_field %} hidden{% endif %}{% for field in line %}{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% endfor %}">
+    <div class="form-group{% if line.fields|length == 1 and line.errors %} errors{% endif %}{% if not line.has_visible_field %} hidden{% endif %}{% for field in line %}{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% endfor %}">
         <div class="row">
             {% for field in line %}
-                <label class="{% if not line.fields|length_is:'1' and forloop.counter != 1 %}col-auto {% else %}col-sm-3 {% endif %}text-left" for="id_{{ field.field.name }}">
+                <label class="{% if not line.fields|length == 1 and forloop.counter != 1 %}col-auto {% else %}col-sm-3 {% endif %}text-left" for="id_{{ field.field.name }}">
                     {{ field.field.label|capfirst }}
                     {% if field.field.field.required %}
                     <span class="text-red">* </span>
                     {% endif %}
                 </label>
-                <div class="{% if not line.fields|length_is:'1' %} col-auto  fieldBox {% else %} col-sm-7 {% endif %}
+                <div class="{% if not line.fields|length == 1 %} col-auto  fieldBox {% else %} col-sm-7 {% endif %}
                              {% if field.field.name %} field-{{ field.field.name }}{% endif %}
                              {% if not field.is_readonly and field.errors %} errors{% endif %}
                              {% if field.field.is_hidden %} hidden {% endif %}
@@ -39,13 +39,13 @@
                         {{ field.field }}
                     {% endif %}
                     <div class="help-block red">
-                        {% if not line.fields|length_is:'1' and not field.is_readonly %}{{ field.errors }}{% endif %}
+                        {% if not line.fields|length == 1 and not field.is_readonly %}{{ field.errors }}{% endif %}
                     </div>
                     {% if field.field.help_text %}
                         <div class="help-block">{{ field.field.help_text|safe }}</div>
                     {% endif %}
                     <div class="help-block text-red">
-                        {% if line.fields|length_is:'1' %}{{ line.errors }}{% endif %}
+                        {% if line.fields|length == 1 %}{{ line.errors }}{% endif %}
                     </div>
                 </div>
             {% endfor %}


### PR DESCRIPTION
replace depcreated length_is with length  for Django4

"
/root/.env/lib/python3.9/site-packages/django/template/defaultfilters.py:617: RemovedInDjango51Warning: The length_is template filter is deprecated in favor of the length template filter and the == operator within an {% if %} tag.
"

warning can be seen when running Django with "python -Wa manage.py runserver"