### PR TITLE
add feature to tell which fieldset tab(s) has the validation error

### DIFF
--- a/jazzmin/templates/jazzmin/includes/horizontal_tabs.html
+++ b/jazzmin/templates/jazzmin/includes/horizontal_tabs.html
@@ -3,15 +3,15 @@
 {% get_sections adminform inline_admin_formsets as forms %}
 
 {% block tabs %}
-<ul class="nav nav-tabs mb-3" role="tablist" id="jazzy-tabs">
-    {% for fieldset in forms %}
-        <li class="nav-item">
-            <a class="nav-link{% if forloop.first %} active{% endif %}" data-toggle="pill" role="tab" aria-controls="{{ fieldset.name|default:general_tab|unicode_slugify }}-tab" aria-selected="{% if forloop.first %}true{% else %}false{% endif %}" href="#{{ fieldset.name|default:general_tab|unicode_slugify }}-tab">
-                {{ fieldset.name|default:general_tab }}
-            </a>
-        </li>
-    {% endfor %}
-</ul>
+    <ul class="nav nav-tabs mb-3" role="tablist" id="jazzy-tabs">
+        {% for fieldset in forms %}
+            <li class="nav-item">
+                <a class="nav-link{% if forloop.first %} active{% endif %}{% if fieldset|has_error %} text-danger{% endif %}" data-toggle="pill" role="tab" aria-controls="{{ fieldset.name|default:general_tab|unicode_slugify }}-tab" aria-selected="{% if forloop.first %}true{% else %}false{% endif %}" href="#{{ fieldset.name|default:general_tab|unicode_slugify }}-tab">
+                    {{ fieldset.name|default:general_tab }}{% if fieldset|has_error %}*{% endif %}
+                </a>
+            </li>
+        {% endfor %}
+    </ul>
 {% endblock tabs %}
 
 <div class="tab-content">

--- a/jazzmin/templatetags/jazzmin.py
+++ b/jazzmin/templatetags/jazzmin.py
@@ -536,3 +536,13 @@ def style_bold_first_word(message: str) -> SafeText:
 @register.filter
 def unicode_slugify(message: str) -> str:
     return slugify(message, allow_unicode=True)
+
+
+@register.filter(name='has_error')
+def has_error(fieldset):
+    if hasattr(fieldset, 'form'):
+        return not set(fieldset.form.errors.keys()).isdisjoint(set(fieldset.fields))
+    elif hasattr(fieldset, 'formset'):
+        return any(fieldset.formset.errors)
+
+    return True


### PR DESCRIPTION
Fixes issue #506 

As demonstrated by the image below, users will immediately know which tab(s) have the errors.

![Screenshot from 2023-09-10 13-29-34](https://github.com/farridav/django-jazzmin/assets/33061220/0f831965-5a6c-4c0a-ac93-f2dda4fb97ad)

