### PR TITLE
Fixed django logout feature 405 method not allowed error

### DIFF
--- a/jazzmin/templates/admin/base.html
+++ b/jazzmin/templates/admin/base.html
@@ -160,9 +160,12 @@
                             <i class="fas fa-key mr-2"></i> {% trans 'Change password' %}
                         </a>
                         <div class="dropdown-divider"></div>
-                        <a href="{% url 'admin:logout' %}" class="dropdown-item">
-                            <i class="fas fa-users mr-2"></i> {% trans 'Log out' %}
-                        </a>
+                        <form action="{% url 'admin:logout' %}" method="post">
+                            {% csrf_token %}
+                            <button type="submit" class="dropdown-item">
+                                <i class="fas fa-users mr-2"></i> {% trans 'Log out' %}
+                            </button>
+                        </form>
                         {% get_user_menu user request.current_app|default:"admin" as user_menu %}
                         {% for link in user_menu %}
                             <div class="dropdown-divider"></div>


### PR DESCRIPTION
In Django, using <a href="{% url 'admin:logout' %}"> triggers a GET request, which isn't accepted by Django's logout view (hence a 405 error). The updated form version sends a POST request, which is required for secure logout and CSRF protection compliance.