### PR TITLE
feat: Make fieldset take all awailable space

### DIFF
--- a/jazzmin/templates/admin/includes/fieldset.html
+++ b/jazzmin/templates/admin/includes/fieldset.html
@@ -28,7 +28,7 @@
                     <span class="text-red">* </span>
                     {% endif %}
                 </label>
-                <div class="{% if not line.fields|length_is:'1' %} col-auto  fieldBox {% else %} col-sm-7 {% endif %}
+                <div class="{% if not line.fields|length_is:'1' %} col-auto  fieldBox {% else %} col-sm-9 {% endif %}
                              {% if field.field.name %} field-{{ field.field.name }}{% endif %}
                              {% if not field.is_readonly and field.errors %} errors{% endif %}
                              {% if field.field.is_hidden %} hidden {% endif %}


### PR DESCRIPTION
In some previous version of the django-jazzmin, this block was full-size, then it was changed to smaller size.

It's better for it to be full-size.