### PR TITLE
Fix TemplateDoesNotExist error in Filer directory listing

### DIFF
--- a/jazzmin/templates/admin/filer/folder/directory_listing.html
+++ b/jazzmin/templates/admin/filer/folder/directory_listing.html
@@ -248,7 +248,7 @@
                 {% if action_form and actions_on_top and paginator.count and not is_popup %}
                     {% filer_actions %}
                 {% endif %}
-                {% include "admin/filer/folder/directory_table.html" %}
+                {% include "admin/filer/folder/directory_table_list.html" %}
                 {% if action_form and actions_on_bottom and paginator.count and not is_popup %}
                     {% filer_actions %}
                 {% endif %}


### PR DESCRIPTION
Fix TemplateDoesNotExist error in Filer directory listing

Issue:
TemplateDoesNotExist error was occurring in Filer directory listing due to a mismatch in template inclusion. Changed include to 
Solution:
Updated template inclusion from "admin/filer/folder/directory_table.html" to "admin/filer/folder/directory_table_list.html" in jazzmin's directory_listing.html.

This commit resolves the reported issue by aligning the template inclusion with the correct path.

Closes: https://github.com/farridav/django-jazzmin/issues/500