### PR TITLE
Add support for Django 5.1 by removing deprecated features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,14 @@ test: check-venv ## Run the test suite
 	@printf "$(CYAN)Running test suite$(COFF)\n"
 	$(environment) pytest
 
+reset_app: check-venv ## Reset the DB for a fresh install.
+	@printf "$(CYAN)Resetting the local DB$(COFF)\n"
+	$(environment) python tests/test_app/manage.py reset
+
 test_app: check-venv ## Run the test app
 	@printf "$(CYAN)Running test app$(COFF)\n"
-	$(environment) python tests/test_app/manage.py migrate
-	$(environment) python tests/test_app/manage.py runserver_plus
+	$(environment) python tests/test_app/manage.py migrate  # Setup db tables etc.
+	$(environment) python tests/test_app/manage.py runserver_plus  # Run development server (with werkzeug debugger).
 
 test_user:  ## Make the test user
 	$(environment) python tests/test_app/manage.py shell -c "from django.contrib.auth.models import User; User.objects.create_superuser('test@test.com', password='test')"

--- a/docs/development.md
+++ b/docs/development.md
@@ -6,24 +6,15 @@ This project manages dependencies using [poetry](https://python-poetry.org/)
 
 Ensure you have poetry installed (`pip install poetry`)
 
-Then get setup with `poetry install`
+Then get setup with `poetry install` you will need to fork the repo and then clone.
 
-    git clone git@github.com:farridav/django-jazzmin.git
+    git clone git@github.com:{github_username}/django-jazzmin.git
     poetry install
 
-## Running the test project
-
-Setup db tables etc.
-
-    python tests/test_app/manage.py migrate
-
-Generate test data
-
-    python tests/test_app/manage.py reset
-
-Run development server (with werkzeug debugger)
-
-    python tests/test_app/manage.py runserver_plus
+## Running the test project (See the [Makefile](../Makefile) for more details)
+    
+    make reset_app
+    make test_app
 
 ## Running the tests
 

--- a/jazzmin/templates/admin/includes/fieldset.html
+++ b/jazzmin/templates/admin/includes/fieldset.html
@@ -19,16 +19,16 @@
 {% endif %}
 
     {% for line in fieldset %}
-    <div class="form-group{% if line.fields|length_is:'1' and line.errors %} errors{% endif %}{% if not line.has_visible_field %} hidden{% endif %}{% for field in line %}{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% endfor %}">
+    <div class="form-group{% if line.fields|length == 1 and line.errors %} errors{% endif %}{% if not line.has_visible_field %} hidden{% endif %}{% for field in line %}{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% endfor %}">
         <div class="row">
             {% for field in line %}
-                <label class="{% if not line.fields|length_is:'1' and forloop.counter != 1 %}col-auto {% else %}col-sm-3 {% endif %}text-left" for="id_{{ field.field.name }}">
+                <label class="{% if not line.fields|length == 1 and forloop.counter != 1 %}col-auto {% else %}col-sm-3 {% endif %}text-left" for="id_{{ field.field.name }}">
                     {{ field.field.label|capfirst }}
                     {% if field.field.field.required %}
                     <span class="text-red">* </span>
                     {% endif %}
                 </label>
-                <div class="{% if not line.fields|length_is:'1' %} col-auto  fieldBox {% else %} col-sm-7 {% endif %}
+                <div class="{% if not line.fields|length == 1 %} col-auto  fieldBox {% else %} col-sm-7 {% endif %}
                              {% if field.field.name %} field-{{ field.field.name }}{% endif %}
                              {% if not field.is_readonly and field.errors %} errors{% endif %}
                              {% if field.field.is_hidden %} hidden {% endif %}
@@ -39,13 +39,13 @@
                         {{ field.field }}
                     {% endif %}
                     <div class="help-block red">
-                        {% if not line.fields|length_is:'1' and not field.is_readonly %}{{ field.errors }}{% endif %}
+                        {% if not line.fields|length == 1 and not field.is_readonly %}{{ field.errors }}{% endif %}
                     </div>
                     {% if field.field.help_text %}
                         <div class="help-block">{{ field.field.help_text|safe }}</div>
                     {% endif %}
                     <div class="help-block text-red">
-                        {% if line.fields|length_is:'1' %}{{ line.errors }}{% endif %}
+                        {% if line.fields|length == 1 %}{{ line.errors }}{% endif %}
                     </div>
                 </div>
             {% endfor %}


### PR DESCRIPTION
There is only one Django feature used here that is removed in >=5.0, which is the `length_is` filter query:

```
RemovedInDjango51Warning: The length_is template filter is deprecated in favour of the length template filter and the == operator within an {% if %} tag.
```

It is a trivial change to make, and the `length` feature if backwards compatible to the earliest support version this repo supports of 2.2.

Preview of `fieldsets`, which has been modified in this PR:
<img width="2559" alt="Screenshot 2024-02-28 at 18 22 25" src="https://github.com/farridav/django-jazzmin/assets/121879791/9b6381d4-6356-4919-80a1-6faa92d96918">


As this is my first PR, I've also added in some QoL changes for new devs working in this repo. Hopefully that's okay 🙂 