### PR TITLE
Allow the creating of new pypi packages from github releases alone

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,31 @@
+name-template: 'v$RESOLVED_VERSION 🌈'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -26,3 +26,16 @@ jobs:
           poetry version prepatch
           poetry config repositories.test_pypi https://test.pypi.org/legacy/
           poetry publish --build -r test_pypi --username __token__ --password ${{ secrets.TEST_PYPI_TOKEN }} || true
+
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter.yml
+          disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -21,5 +21,8 @@ jobs:
 
       - name: Deploy to testpypi.org
         run: |
+          LATEST_RELEASE=${curl "https://api.github.com/repos/farridav/django-jazzmin/tags" | jq -r '.[0].name'/#v}
+          poetry version $LATEST_RELEASE
+          poetry version patch
           poetry config repositories.test_pypi https://test.pypi.org/legacy/
           poetry publish --build -r test_pypi --username __token__ --password ${{ secrets.TEST_PYPI_TOKEN }} || true

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Deploy to testpypi.org
         run: |
-          LATEST_RELEASE=${curl "https://api.github.com/repos/farridav/django-jazzmin/tags" | jq -r '.[0].name'/#v}
+          LATEST_RELEASE=${curl -s "https://api.github.com/repos/farridav/django-jazzmin/tags" | jq -r '[0].name[1:]'}
           poetry version $LATEST_RELEASE
           poetry version patch
           poetry config repositories.test_pypi https://test.pypi.org/legacy/

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -23,6 +23,6 @@ jobs:
         run: |
           LATEST_RELEASE=${curl -s "https://api.github.com/repos/farridav/django-jazzmin/tags" | jq -r '[0].name[1:]'}
           poetry version $LATEST_RELEASE
-          poetry version patch
+          poetry version prepatch
           poetry config repositories.test_pypi https://test.pypi.org/legacy/
           poetry publish --build -r test_pypi --username __token__ --password ${{ secrets.TEST_PYPI_TOKEN }} || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,4 +21,5 @@ jobs:
 
       - name: Deploy to pypi.org
         run: |
+          poetry version ${GITHUB_REF_NAME/#v}
           poetry publish --build --username __token__ --password ${{ secrets.PYPI_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-jazzmin"
-version = "2.6.1"
+version = "0.0.0"
 description = "Drop-in theme for django admin, that utilises AdminLTE 3 & Bootstrap 4 to make yo' admin look jazzy"
 license = "MIT"
 authors = ["Shipit <packages@shipit.ltd>"]


### PR DESCRIPTION
This _should_ allow for us to create releases on github with zero code changes, allowing for a test, code, review, merge and release when ready from main approach

- `testpypi` (which i use to validate the package build and deploy works as expected) will continually bump patches on the latest published version
- pypi.org will receive the version of the tag created in github (with the `v` prefix removed)
- Package versions need not be tracked in the code at all