### PR TITLE
Fix the release-drafter plugin when getting the LATEST_RELEASE

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Deploy to testpypi.org
         run: |
-          LATEST_RELEASE=${curl -s "https://api.github.com/repos/farridav/django-jazzmin/tags" | jq -r '[0].name[1:]'}
+          LATEST_RELEASE=$(curl -s "https://api.github.com/repos/farridav/django-jazzmin/tags" | jq -r '.[0].name[1:]')
           poetry version $LATEST_RELEASE
           poetry version prepatch
           poetry config repositories.test_pypi https://test.pypi.org/legacy/


### PR DESCRIPTION
Fix an issue with setting the `LATEST_RELEASE` flag. 

Should fix https://github.com/farridav/django-jazzmin/actions/runs/8481950943/job/23246449110 (at least when tested locally)