### PR TITLE
Fix version bumping test packages to avoid package not publishing

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -21,9 +21,10 @@ jobs:
 
       - name: Deploy to testpypi.org
         run: |
-          LATEST_RELEASE=$(curl -s "https://api.github.com/repos/farridav/django-jazzmin/tags" | jq -r '.[0].name[1:]')
+          # Using `pypi` rather than our own tags as we don't create a "release" for test version of our package.
+          LATEST_RELEASE=$(curl -s https://test.pypi.org/rss/project/django-jazzmin/releases.xml | sed -n 's/\s*<title>\([{a,b}0-9.]*\).*/\1/p' | head -n 2 | xargs)
           poetry version $LATEST_RELEASE
-          poetry version prepatch
+          poetry version prerelease  # Using `prerelease` rather than `prepatch` due to a bug in Poetry (latest checked 1.8.1 - https://github.com/python-poetry/poetry/issues/879)
           poetry config repositories.test_pypi https://test.pypi.org/legacy/
           poetry publish --build -r test_pypi --username __token__ --password ${{ secrets.TEST_PYPI_TOKEN }} || true
 


### PR DESCRIPTION
Even in `test.pypi` if you try and publish a package with a version already released, then PyPi will block you. Our current method for determining the latest version uses the "releases" on GH, but for test releases we don't create one, as I'm guessing we should only create "releases" for production-ready code.

So using PyPi servers to grab the latest test version.

Also using `prerelease` instead of `prepatch` due to a bug in Poetry which doesn't autoincrement the package number [0].

[0] https://github.com/python-poetry/poetry/issues/879