### PR TITLE
Fix again the strategy for determining the latest version released.

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -21,8 +21,16 @@ jobs:
 
       - name: Deploy to testpypi.org
         run: |
-          # Using `pypi` rather than our own tags as we don't create a "release" for test version of our package.
-          LATEST_RELEASE=$(curl -s https://test.pypi.org/rss/project/django-jazzmin/releases.xml | sed -n 's/\s*<title>\([{a,b}0-9.]*\).*/\1/p' | head -n 2 | xargs)
+          # Need to check both Test PyPi and GH releases as we need to version bump the patch
+          # version everytime we merge in a PR, but once we release a new production release, we
+          # need to bump from the new release. So we grab the latest releases from both sources,
+          # then reverse sort them to get highest version! Simples :D
+          LATEST_RELEASE_TEST_PYPI=$(curl -s https://test.pypi.org/rss/project/django-jazzmin/releases.xml | sed -n 's/\s*<title>\([{a,b}0-9.]*\).*/\1/p' | head -n 2 | xargs)
+          LATEST_RELEASE_GITHUB=$(curl -s "https://api.github.com/repos/farridav/django-jazzmin/tags" | jq -r '.[0].name[1:]')
+          LATEST_RELEASE=$(printf "${LATEST_RELEASE_GITHUB}\n${LATEST_RELEASE_TEST_PYPI}" | sort -V -r)
+
+          # Now we can bump the version correctly to release a new version nicely base on the
+          # latest GH release.
           poetry version $LATEST_RELEASE
           poetry version prerelease  # Using `prerelease` rather than `prepatch` due to a bug in Poetry (latest checked 1.8.1 - https://github.com/python-poetry/poetry/issues/879)
           poetry config repositories.test_pypi https://test.pypi.org/legacy/


### PR DESCRIPTION
Since we want to auto-publish the a test version of Django Jazzmin each time a PR is merged, we have to take into account the following:
* You need to know which test versions have already been released on test PyPi so, between production releases, you don't have tag clashes.
* When a production version is released to PyPi you need to start releasing test version using the new production version. Otherwise you'll stay on the initial version constantly.

### Before
| Test Version | Production Version |
|--------|--------|
| 2.6.2a0 | 2.6.2 |
| 2.6.2a1 | 2.6.2 |
| 2.6.2a1 | 2.7.0 | # Release to production
| 2.6.2a2 | 2.7.0 |

### After
| Test Version | Production Version |
|--------|--------|
| 2.6.2a0 | 2.6.2 |
| 2.6.2a1 | 2.6.2 |
| 2.6.2a1 | 2.7.0 | # Release to production
| 2.6.7a0 | 2.7.0 |
