### PR TITLE
Improve deployment for test builds

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -3,11 +3,13 @@ name: Deploy to test.pypi.org
 on:
   push:
     branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
-  deploy:
+  # Build the python package even on PRs to ensure we're able to build the package properly.
+  build:
     runs-on: ubuntu-20.04
-    steps:
       - uses: actions/checkout@v4
 
       - name: Set up Python
@@ -33,14 +35,48 @@ jobs:
           # latest GH release.
           poetry version $LATEST_RELEASE
           poetry version prerelease  # Using `prerelease` rather than `prepatch` due to a bug in Poetry (latest checked 1.8.1 - https://github.com/python-poetry/poetry/issues/879)
+          poetry build
+
+      - name: Save build
+        uses: actions/cache/save@v4
+        id: build-cache
+        with:
+          path: |
+            dist/
+          key: cache-${{ github.run_id }}-${{ github.run_attempt }}
+
+  deploy:
+    runs-on: ubuntu-20.04
+    needs: build
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+          cache: pip
+
+      - name: Install dependencies
+        run: python -m pip install --upgrade pip poetry
+
+      - name: Get build
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            dist/
+          key: cache-${{ github.run_id }}-${{ github.run_attempt }}
+
+      - name: Deploy to testpypi.org
+        run: |
           poetry config repositories.test_pypi https://test.pypi.org/legacy/
-          poetry publish --build -r test_pypi --username __token__ --password ${{ secrets.TEST_PYPI_TOKEN }} || true
+          poetry publish -r test_pypi --username __token__ --password ${{ secrets.TEST_PYPI_TOKEN }} || true
 
   update_release_draft:
     permissions:
       contents: write
       pull-requests: read
     runs-on: ubuntu-latest
+    needs: deploy
     steps:
       - uses: release-drafter/release-drafter@v5
         with:


### PR DESCRIPTION
As we've had a few issues with deployments recently, I thought it might be useful to spot these issues earlier if we get each PR to run the preliminary steps of the build process. This should also stop regression-like issues (e.g., newer versions of poetry breaking our build process).