### PR TITLE
fix recent list on index.html not showing the full card for deleted item

### DIFF
--- a/jazzmin/templates/admin/index.html
+++ b/jazzmin/templates/admin/index.html
@@ -117,6 +117,10 @@
                                                 </ul>
                                             {% endif %}
                                         </div>
+                                    {% else %}
+                                    <div class="timeline-body">
+                                        {{ entry }}
+                                    </div>
                                     {% endif %}
                                 </div>
                             </div>
@@ -129,5 +133,6 @@
             </div>
         </div>
     </div>
+
 
 {% endblock %}


### PR DESCRIPTION
With this PR fixed, the behaviour when the user deletes an item (entry) and navigates back to the dashboard (index.html) and the card is not displayed as the rest as in the screenshot
before the change:
![Screenshot 2024-10-22 at 17 16 26](https://github.com/user-attachments/assets/efd2710b-e60b-448d-b720-12ad5c950c96)

After the change, the card is displayed as the addition card, but for deleted item

Is this on purpose, btw? I was searching for a fix for this issue https://github.com/farridav/django-jazzmin/issues/603 when I found the card behaviour.