### PR TITLE
Update references for the master branch to become main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,9 @@
 name: Build
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -2,9 +2,9 @@
 name: Deploy to test.pypi.org
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 # Only allow the latest workflow to run and cancel all others. There is also job-level concurrency
 # enabled (see below), which is specified slightly differently.
@@ -78,11 +78,11 @@ jobs:
         run: poetry config repositories.test_pypi https://test.pypi.org/legacy/
 
       - name: Deploy to testpypi.org
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: poetry publish -r test_pypi --dist-dir dist/ --username __token__ --password ${{ secrets.TEST_PYPI_TOKEN }} || true
 
       - name: Deploy to testpypi.org (Dry Run)
-        if: github.ref != 'refs/heads/master'
+        if: github.ref != 'refs/heads/main'
         run: poetry publish -r test_pypi --dist-dir dist/ --username __token__ --password ${{ secrets.TEST_PYPI_TOKEN }} || true
 
   update_release_draft:
@@ -91,7 +91,7 @@ jobs:
       pull-requests: read
     runs-on: ubuntu-latest
     needs: deploy
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: release-drafter/release-drafter@v5
         with:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ them as quickly as I would like, but im trying to get through them all now, hope
 [![PyPI version](https://badge.fury.io/py/django-jazzmin.svg)](https://pypi.python.org/pypi/django-jazzmin/)
 ![Python versions](https://img.shields.io/badge/python-%3E=3.8-brightgreen)
 ![Django Versions](https://img.shields.io/badge/django-%3E=4.2-brightgreen)
-[![Coverage Status](https://coveralls.io/repos/github/farridav/django-jazzmin/badge.svg?branch=master)](https://coveralls.io/github/farridav/django-jazzmin?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/farridav/django-jazzmin/badge.svg?branch=main)](https://coveralls.io/github/farridav/django-jazzmin?branch=main)
 
 Drop-in theme for django admin, that utilises AdminLTE 3.2 & Bootstrap 5 to make yo' admin look jazzy
 
@@ -33,7 +33,7 @@ pip install django-jazzmin
 
 ## Documentation
 
-See [Documentation](https://django-jazzmin.readthedocs.io) or [Test App](https://github.com/farridav/django-jazzmin/tree/master/tests/test_app/library/settings.py)
+See [Documentation](https://django-jazzmin.readthedocs.io) or [Test App](https://github.com/farridav/django-jazzmin/tree/main/tests/test_app/library/settings.py)
 
 ## Features
 
@@ -120,7 +120,7 @@ This was initially a Fork of <https://github.com/wuyue92tree/django-adminlte-ui>
 deserved its own package, big thanks to @wuyue92tree for all of his initial hard work, we are still patching into that
 project were possible, but this project has taken a different direction.
 
-The javascript modal implementation uses some code from [django-admin-interface](https://github.com/fabiocaccamo/django-admin-interface/blob/master/admin_interface/static/admin/js/popup_response.js), so thanks to @fabiocaccamo for original work
+The javascript modal implementation uses some code from [django-admin-interface](https://github.com/fabiocaccamo/django-admin-interface/blob/main/admin_interface/static/admin/js/popup_response.js), so thanks to @fabiocaccamo for original work
 
 - Based on AdminLTE 3: <https://adminlte.io/>
 - Using Bootstrap 5: <https://getbootstrap.com/>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -352,7 +352,7 @@ Namely:
 - `LOCALE_DIRS` is setup
 - `LANGUAGES` have been defined
 
-See our [test app settings](https://github.com/farridav/django-jazzmin/tree/master/tests/test_app/library/settings.py)
+See our [test app settings](https://github.com/farridav/django-jazzmin/tree/main/tests/test_app/library/settings.py)
 for a practical example.
 
 ![Language chooser](./img/language_chooser.png)
@@ -367,7 +367,7 @@ defaults to `False`
 ### Adding extra actions to model's form view
 
 Add a template for your model on your main template directory,
-e.g [app/templates/admin/app_name/model_name/submit_line.html](https://github.com/farridav/django-jazzmin/tree/master/tests/test_app/library/books/templates/admin/loans/bookloan/submit_line.html)
+e.g [app/templates/admin/app_name/model_name/submit_line.html](https://github.com/farridav/django-jazzmin/tree/main/tests/test_app/library/books/templates/admin/loans/bookloan/submit_line.html)
 
 ```djangotemplate
 {# extends "admin/submit_line.html" #}

--- a/docs/development.md
+++ b/docs/development.md
@@ -27,7 +27,7 @@ Run development server (with werkzeug debugger)
 
 ## Running the tests
 
-Tests are run via github actions on any pull request into `master`, and are written for use with the [pytest](https://docs.pytest.org/en/latest/)
+Tests are run via github actions on any pull request into `main`, and are written for use with the [pytest](https://docs.pytest.org/en/latest/)
 framework, we should have good enough tests for you to base your own off of, though where we are lacking, feel free to contribute,
 but keep it clean, concise and simple, leave the magic to the wizards.
 
@@ -39,7 +39,7 @@ Run against all supported Python and Django Versions using `tox`
 ## Contribution guidelines
 
 - Fork the project
-- Make a pull request against this repositories `master` branch,
+- Make a pull request against this repositories `main` branch,
 - Include tests unless its a trivial change
 - Add a screenshot if your proposing UI changes
 - Demonstrate the change within the `test_app` if possible
@@ -71,7 +71,7 @@ or use a string that is already translated upstream in Django.
 4. cd ../
 5. Run ./cli.py locales --prune de to remove the django provided strings
 6. Go through the strings in the locale file, any that are not genuinely new strings introduced by jazzmin, find them in the codebase, and try making them match the ones provided in djangos admin/admin docs translation files
-    - [Django admin translations](https://raw.githubusercontent.com/django/django/master/django/contrib/admindocs/locale/)
-    - [Django admin docs translations](https://raw.githubusercontent.com/django/django/master/django/contrib/admin/locale/de/LC_MESSAGES/django.po)
+    - [Django admin translations](https://raw.githubusercontent.com/django/django/main/django/contrib/admindocs/locale/)
+    - [Django admin docs translations](https://raw.githubusercontent.com/django/django/main/django/contrib/admin/locale/de/LC_MESSAGES/django.po)
 
 Once you have finished, run `makemessages` again, until the file contains ONLY unique strings to jazzmin, there should only be a handful


### PR DESCRIPTION
After master branch was renamed to become main, PR checks stopped running. And some of the docs now have incorrect links. This PR updates references for master branch.