### PR TITLE
Rely on message level instead of tag to allow overriding MESSAGE_TAGS

### DIFF
--- a/jazzmin/templates/admin/base.html
+++ b/jazzmin/templates/admin/base.html
@@ -283,25 +283,25 @@
                     <section id="content" class="content">
                         {% block messages %}
                             {% for message in messages %}
-                                {% if message.tags == 'success' %}
+                                {% if message.level == DEFAULT_MESSAGE_LEVELS.SUCCESS %}
                                     <div class="alert alert-success alert-dismissible">
                                         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×
                                         </button>
                                         <i class="icon fa fa-check"></i>{{ message|capfirst }}
                                     </div>
-                                {% elif message.tags == 'error' %}
+                                {% elif message.level == DEFAULT_MESSAGE_LEVELS.ERROR %}
                                     <div class="alert alert-danger alert-dismissible">
                                         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×
                                         </button>
                                         <i class="icon fa fa-ban"></i>{{ message|capfirst }}
                                     </div>
-                                {% elif message.tags == 'warning' %}
+                                {% elif message.level == DEFAULT_MESSAGE_LEVELS.WARNING %}
                                     <div class="alert alert-warning alert-dismissible">
                                         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×
                                         </button>
                                         <i class="icon fa fa-exclamation-triangle"></i>{{ message|capfirst }}
                                     </div>
-                                {% elif message.tags == 'info' %}
+                                {% elif message.level == DEFAULT_MESSAGE_LEVELS.INFO %}
                                     <div class="alert alert-info alert-dismissible">
                                         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×
                                         </button>


### PR DESCRIPTION
Currently in base.html, jazzmin compares `message.tags` to hardcoded strings ("success", "error"...) to decide how to display the messages.

According to the documentation, "message tags are used as CSS classes to customize message style based on message type":
https://docs.djangoproject.com/en/5.1/ref/contrib/messages/#message-tags

The `MESSAGE_TAGS` setting could be overridden in the global settings.py of a project to handle messages in a specific way in other parts of the project (I mean outside jazzmin).

A more reliable way would be to use messages levels that are made available in DEFAULT_MESSAGE_LEVELS:
https://docs.djangoproject.com/en/5.1/ref/contrib/messages/#displaying-messages

This problem was already raised here though the user ended up removing MESSAGE_TAGS from his settings: https://github.com/farridav/django-jazzmin/issues/344