### PR TITLE
Fix hide_appsx

### DIFF
--- a/jazzmin/templatetags/jazzmin.py
+++ b/jazzmin/templatetags/jazzmin.py
@@ -78,7 +78,7 @@ def get_side_menu(context: Context, using: str = "available_apps") -> List[Dict]
         app_label = app["app_label"]
         app_custom_links = custom_links.get(app_label, [])
         app["icon"] = options["icons"].get(app_label, options["default_icon_parents"])
-        if app_label in options["hide_apps"]:
+        if app_label.lower() in options["hide_apps"]:
             continue
 
         menu_items = []


### PR DESCRIPTION
This PR fixes the case sensitivity issue introduced in [PR #605](https://github.com/farridav/django-jazzmin/pull/605), which caused the hide_apps setting to stop working correctly.

# Changes Made
Applies the .lower() method to the hide_apps comparison in the get_side_menu method to ensure consistent case matching.
This adjustment is made later in the process to preserve the group label's original case that appears to be the reason for the initial removal.

# Why This is Needed
Without this fix, users who rely on hide_apps may find that their configurations no longer work if their app names contain uppercase letters.

# Testing
Manually tested by configuring hide_apps with both uppercase and lowercase app names.
Confirmed that the group labels retain their original casing.

# Impact
This change should only affect the case sensitivity of hide_apps and should not impact other functionalities. No breaking changes expected.