### PR TITLE
Fix: Use Django Static Tag for Theme Assets in base.html

### DIFF
--- a/jazzmin/templates/admin/base.html
+++ b/jazzmin/templates/admin/base.html
@@ -23,11 +23,11 @@
 
     <!-- Bootswatch theme -->
     {% if jazzmin_ui.theme.name != 'default' %}
-        <link rel="stylesheet" href="{{ jazzmin_ui.theme.src }}" id="jazzmin-theme" />
+        <link rel="stylesheet" href="{% static jazzmin_ui.theme.src %}" id="jazzmin-theme" />
     {% endif %}
 
     {% if jazzmin_ui.dark_mode_theme %}
-        <link rel="stylesheet" href="{{ jazzmin_ui.dark_mode_theme.src }}" id="jazzmin-dark-mode-theme" media="(prefers-color-scheme: dark)"/>
+        <link rel="stylesheet" href="{% static jazzmin_ui.dark_mode_theme.src %}" id="jazzmin-dark-mode-theme" media="(prefers-color-scheme: dark)"/>
     {% endif %}
 
     <!-- Custom fixes for django -->


### PR DESCRIPTION
# Fix: Use Django Static Tag for Theme Assets in base.html

## Overview
This PR fixes an issue in `templates/admin/base.html` where the custom theme and dark mode theme CSS files were being referenced directly via `{{ jazzmin_ui.theme.src }}` instead of using Django’s `{% static %}` tag. This caused a `Missing staticfiles manifest entry` error when `ManifestStaticFilesStorage` was used in production (`DEBUG = False`).

## Issue
- When `ManifestStaticFilesStorage` is enabled, Django renames static files with a hash (e.g., `bootstrap.min.css` → `bootstrap.min.039ad78474a5.css`).
- The existing template references the file directly:
  ```html
  <link rel="stylesheet" href="{{ jazzmin_ui.theme.src }}" id="jazzmin-theme" />
  ```
  - This bypasses Django’s static file resolution.
  - Results in a `ValueError` in production when the original file name no longer exists.

## Fix
Updated `base.html` to properly resolve static file URLs using `{% static %}`:
  ```html
  {% if jazzmin_ui.theme.name != 'default' %}
      <link rel="stylesheet" href="{% static jazzmin_ui.theme.src %}" id="jazzmin-theme" />
  {% endif %}

  {% if jazzmin_ui.dark_mode_theme %}
      <link rel="stylesheet" href="{% static jazzmin_ui.dark_mode_theme.src %}" id="jazzmin-dark-mode-theme" media="(prefers-color-scheme: dark)"/>
  {% endif %}
  ```

## Impact
- Fixes `collectstatic` manifest errors in production.
- Ensures Django correctly resolves and serves the hashed static files.
- Improves compatibility with Django’s recommended static file handling.

## Testing
- Verified that static files load correctly in **development (`DEBUG = True`)**.
- Tested in **production (`DEBUG = False`)** with `ManifestStaticFilesStorage` enabled.
- Confirmed that theme assets are served with their hashed filenames.

## Notes
- This is a non-breaking change and aligns Jazzmin with Django’s best practices for static file management.

Looking forward to your review! 🚀
