### PR TITLE
Update main.css: set width/height for the GeoDjango OSM widget

### DIFF
--- a/jazzmin/static/jazzmin/css/main.css
+++ b/jazzmin/static/jazzmin/css/main.css
@@ -925,3 +925,10 @@ body.jazzmin-login-page {
     float: left;
     width: 100%;
 }
+
+/* GIS MAPS */
+.dj_map {
+    width: 600px;
+    height: 400px;
+}
+


### PR DESCRIPTION
It's necessary to have in the CSS the width and height of the map object. Sure it could be added as local tweak, but it's a base django thing.

Fixes #610 