### PR TITLE
Fix: Show model name in all recent actions (fixes #538)

### DIFF
--- a/jazzmin/templates/admin/index.html
+++ b/jazzmin/templates/admin/index.html
@@ -96,14 +96,13 @@
                                             <a href="{{ entry.get_admin_url }}">{{ entry.object_repr }}</a>
                                         {% endif %}
 
-                                        {% if entry.model %}
-                                            <span class="mini quiet">
-                                                {% filter capfirst %}
-                                                    {{ entry.model }}
-                                                {% endfilter %}
+                                        {% if entry.content_type %}
+                                            <span class="mini quiet text-muted">
+                                                {{ entry.content_type.model }}
                                             </span>
                                         {% endif %}
                                     </h3>
+
                                     {% if not entry.is_deletion %}
                                         <div class="timeline-body">
                                             {% if entry.is_addition %}


### PR DESCRIPTION
This pull request addresses [Issue #538](https://github.com/farridav/django-jazzmin/issues/538) by ensuring that the model name is displayed alongside each recent action (additions, changes, deletions) in the Django Jazzmin dashboard.

Previously, users had to click the object link to determine which model was affected. Now, the model name (e.g., book) is shown directly in the UI, just like Django's default admin behavior.

Note: Only a single file was modified: `jazzmin/templates/admin/index.html`. No other changes were made to the codebase.

<img width="354" height="674" alt="Screenshot 2025-08-02 at 18 56 47" src="https://github.com/user-attachments/assets/7f1245ed-6746-4913-9dca-c6a9569d9b5f" />

<img width="665" height="252" alt="Screenshot 2025-08-02 at 19 01 16" src="https://github.com/user-attachments/assets/3fe8b88c-9b1f-45fd-8a6f-1cca32c3fe32" />

